### PR TITLE
Limit navigation to home page header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-Create a personal advertising website for this lawyer https://www.lawyer.com/james-bryce-kennedy-tx.html
+# James B. Kennedy, Jr. Personal Injury Website
+
+This repository contains a marketing website for attorney James Bryce Kennedy, Jr. The site now
+includes a robust multi-page experience featuring a ten-article blog, dedicated privacy policy,
+disclaimer, and contact pages, along with a cookie consent banner that appears across the
+experience. The home page still highlights his board certification, admissions, practice areas,
+and contact information for his El Paso, Texas law office.
+
+## Getting Started
+
+Open `index.html` in any modern web browser. All styling and interactions are handled with the
+static assets in `assets/css/styles.css` and `assets/js/main.js`—no build step is required. Blog
+articles live in the `blog/` directory, and new policy/contact pages are placed at the project
+root.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,1002 @@
+:root {
+  --color-primary: #c3562e;
+  --color-primary-dark: #8d3a19;
+  --color-secondary: #1e2a36;
+  --color-accent: #f2c94c;
+  --color-background: #f7f4f0;
+  --color-surface: #ffffff;
+  --color-muted: #6b7a89;
+  --color-text: #1a1f24;
+  --font-heading: "Lora", serif;
+  --font-body: "Work Sans", "Segoe UI", sans-serif;
+  --shadow-soft: 0 20px 40px rgba(30, 42, 54, 0.12);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 10px;
+  --max-width: 1120px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-body);
+  color: var(--color-text);
+  background-color: var(--color-background);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--color-primary);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: min(100% - 2.5rem, var(--max-width));
+  margin: 0 auto;
+}
+
+.split {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(2rem, 4vw, 4rem);
+  align-items: start;
+}
+
+section {
+  padding: clamp(3rem, 8vw, 6rem) 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5 {
+  font-family: var(--font-heading);
+  color: var(--color-secondary);
+  margin: 0 0 0.75em;
+}
+
+h1 {
+  font-size: clamp(2.5rem, 4vw, 3.5rem);
+  line-height: 1.1;
+}
+
+h2 {
+  font-size: clamp(2rem, 3vw, 2.75rem);
+  line-height: 1.2;
+}
+
+h3 {
+  font-size: clamp(1.5rem, 2.5vw, 1.8rem);
+}
+
+p {
+  margin: 0 0 1.25rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  text-align: center;
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
+  color: #fff;
+  box-shadow: 0 15px 30px rgba(195, 86, 46, 0.4);
+}
+
+.btn.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px rgba(195, 86, 46, 0.35);
+}
+
+.btn.secondary {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+}
+
+.btn.secondary:hover {
+  transform: translateY(-2px);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background-color: rgba(255, 255, 255, 0.98);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  box-shadow: 0 8px 24px rgba(17, 24, 31, 0.08);
+}
+
+.site-header .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1rem 0;
+}
+
+.branding {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.logo {
+  background: var(--color-secondary);
+  color: #fff;
+  font-weight: 700;
+  font-size: 1.2rem;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  letter-spacing: 1px;
+}
+
+.identity {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.identity .name {
+  font-weight: 600;
+}
+
+.identity .tagline {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.25rem;
+  font-weight: 500;
+  color: var(--color-secondary);
+}
+
+.site-nav a:hover {
+  color: var(--color-primary);
+}
+
+.cta-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-secondary);
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  white-space: nowrap;
+  box-shadow: 0 10px 25px rgba(30, 42, 54, 0.2);
+}
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  gap: 0.25rem;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.nav-toggle span {
+  width: 26px;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--color-secondary);
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.hero {
+  background: radial-gradient(circle at top right, rgba(195, 86, 46, 0.15), transparent 55%),
+    linear-gradient(160deg, #1e2a36 0%, #11181f 60%);
+  color: #fff;
+  padding-top: clamp(6rem, 10vw, 8rem);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero h1 {
+  color: #f5f8fb;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" fill="none"><path d="M0 100C0 44.7715 44.7715 0 100 0H200V200H0V100Z" fill="rgba(255,255,255,0.04)"/></svg>');
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.hero .container {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(2rem, 5vw, 5rem);
+  align-items: center;
+}
+
+.hero-content .eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  color: var(--color-accent);
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.hero-content .lead {
+  font-size: 1.05rem;
+  color: rgba(255, 255, 255, 0.75);
+  max-width: 38ch;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  margin: 2rem 0 1.5rem;
+  flex-wrap: wrap;
+}
+
+.hero-highlights {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.hero-highlights li::before {
+  content: "\2713";
+  margin-right: 0.75rem;
+  color: var(--color-accent);
+}
+
+.hero-card {
+  display: flex;
+}
+
+.hero-card-inner {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-lg);
+  padding: clamp(2rem, 4vw, 2.75rem);
+  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(10px);
+}
+
+.hero-card-inner h2 {
+  color: #f6f8fb;
+  margin-bottom: 1.5rem;
+}
+
+.hero-card-inner ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.about {
+  background: var(--color-background);
+}
+
+.about-text p {
+  font-size: 1.05rem;
+}
+
+.about-credentials {
+  display: grid;
+  gap: 1rem;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.credential .label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.credential .value {
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--color-secondary);
+}
+
+.practice-areas {
+  background: var(--color-surface);
+}
+
+.practice-areas .section-lead {
+  max-width: 60ch;
+  color: var(--color-muted);
+}
+
+.practice-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.75rem;
+  margin-top: 2.5rem;
+}
+
+.practice-card {
+  background: var(--color-background);
+  border-radius: var(--radius-md);
+  padding: 1.75rem;
+  border: 1px solid rgba(30, 42, 54, 0.08);
+  box-shadow: 0 15px 30px rgba(30, 42, 54, 0.06);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.practice-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 20px 40px rgba(30, 42, 54, 0.1);
+}
+
+.experience {
+  background: var(--color-background);
+}
+
+.timeline {
+  list-style: none;
+  margin: 2rem 0 0;
+  padding: 0;
+  border-left: 2px solid rgba(30, 42, 54, 0.1);
+}
+
+.timeline li {
+  padding-left: 1.5rem;
+  position: relative;
+  margin-bottom: 2rem;
+}
+
+.timeline li::before {
+  content: "";
+  position: absolute;
+  left: -0.65rem;
+  top: 0.35rem;
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 50%;
+  background: var(--color-primary);
+  box-shadow: 0 0 0 6px rgba(195, 86, 46, 0.15);
+}
+
+.timeline-year {
+  font-weight: 600;
+  color: var(--color-secondary);
+}
+
+.timeline-body h3 {
+  margin-bottom: 0.35rem;
+}
+
+.experience-cta {
+  display: flex;
+  justify-content: center;
+}
+
+.quote-card {
+  background: var(--color-surface);
+  padding: clamp(2rem, 5vw, 3rem);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  font-size: 1.05rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.quote-card p {
+  font-family: var(--font-heading);
+  font-style: italic;
+  color: var(--color-secondary);
+}
+
+.credentials {
+  background: var(--color-surface);
+}
+
+.credential-lists {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2rem;
+  margin-top: 1.5rem;
+}
+
+.credential-lists ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: var(--color-muted);
+}
+
+.education ul {
+  list-style: none;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.education li {
+  background: var(--color-background);
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(30, 42, 54, 0.08);
+  box-shadow: 0 10px 25px rgba(30, 42, 54, 0.08);
+}
+
+.education .degree {
+  display: block;
+  font-weight: 600;
+  color: var(--color-secondary);
+}
+
+.education .school {
+  display: block;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.values {
+  background: var(--color-background);
+}
+
+.values-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.75rem;
+  margin-top: 2.5rem;
+}
+
+.values-grid article {
+  background: var(--color-surface);
+  padding: 2rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(30, 42, 54, 0.07);
+  box-shadow: 0 15px 30px rgba(30, 42, 54, 0.08);
+}
+
+.contact {
+  background: linear-gradient(135deg, rgba(30, 42, 54, 0.92), rgba(30, 42, 54, 0.98)),
+    url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" fill="none"><path d="M80 0H160V160H0V80C0 35.8172 35.8172 0 80 0Z" fill="rgba(195,86,46,0.08)"/></svg>');
+  color: #fff;
+}
+
+.contact .container {
+  align-items: stretch;
+}
+
+.contact-info h2 {
+  color: #fff;
+}
+
+.contact-info p,
+.contact-details,
+.contact-details p,
+.contact-details a {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.contact-details {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.contact-details .label {
+  display: block;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.75rem;
+  color: var(--color-accent);
+  margin-bottom: 0.35rem;
+}
+
+.contact-form {
+  background: rgba(255, 255, 255, 0.08);
+  padding: clamp(2rem, 5vw, 3rem);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+}
+
+.contact-form h3 {
+  color: #fff;
+}
+
+.contact-form form {
+  display: grid;
+  gap: 1rem;
+}
+
+.contact-form label {
+  display: grid;
+  gap: 0.5rem;
+  font-weight: 500;
+}
+
+.contact-form input,
+.contact-form textarea {
+  border-radius: var(--radius-sm);
+  border: none;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.contact-form input:focus,
+.contact-form textarea:focus {
+  outline: 2px solid var(--color-accent);
+}
+
+.contact-form .disclaimer {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.75);
+  margin: 0;
+}
+
+.contact-form button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.site-footer {
+  background: #101820;
+  color: rgba(255, 255, 255, 0.75);
+  padding: 2rem 0;
+}
+
+.site-footer .container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.footer-links {
+  display: flex;
+  gap: 1.5rem;
+  font-weight: 500;
+}
+
+.footer-links a {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.footer-links a:hover {
+  color: #fff;
+}
+
+.footer-links a.active {
+  color: #ffffff;
+  font-weight: 600;
+}
+
+@media (max-width: 1100px) {
+  .site-header .container {
+    position: relative;
+    gap: 1rem;
+  }
+
+  .site-nav {
+    position: absolute;
+    inset: calc(100% + 0.75rem) 0 auto;
+    background: rgba(247, 244, 240, 0.98);
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 1.25rem 1.5rem;
+    gap: 1rem;
+    box-shadow: 0 20px 40px rgba(30, 42, 54, 0.15);
+    border-radius: var(--radius-md);
+    transform: translateY(-15px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    z-index: 200;
+  }
+
+  .site-nav a {
+    color: var(--color-secondary);
+    font-weight: 600;
+  }
+
+  .site-nav.open {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  .nav-toggle {
+    display: flex;
+    margin-left: auto;
+  }
+
+  .cta-pill {
+    display: none;
+  }
+}
+
+@media (max-width: 980px) {
+  .hero .container,
+  .split {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-card {
+    order: -1;
+  }
+}
+
+@media (max-width: 768px) {
+  .site-header .container {
+    padding: 0.75rem 0;
+  }
+
+  .hero .container,
+  .split {
+    gap: 2.5rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .container {
+    width: min(100% - 1.75rem, 100%);
+  }
+
+  section {
+    padding: 3rem 0;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .practice-card,
+  .values-grid article,
+  .education li,
+  .quote-card,
+  .contact-form {
+    padding: 1.5rem;
+  }
+}
+
+/* Interior pages and blog */
+.interior-page .site-header {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.interior-page .cta-pill {
+  display: inline-flex;
+}
+
+.page-hero,
+.blog-hero,
+.article-hero {
+  padding: 6rem 0 4rem;
+  background: linear-gradient(135deg, #0d1b2a 0%, #1f2c3f 100%);
+  color: #ffffff;
+  text-align: center;
+}
+
+.blog-hero {
+  background: linear-gradient(135deg, #11263c, #153451);
+}
+
+.article-hero {
+  background: linear-gradient(135deg, #0d1b2a, #29405c);
+}
+
+.page-hero .lead,
+.blog-hero .lead,
+.article-hero .lead {
+  max-width: 48rem;
+  margin: 1rem auto 0;
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.policy-section,
+.contact-detail,
+.map-section,
+.blog-listing,
+.article-content {
+  padding: 4rem 0;
+}
+
+.policy-section h2,
+.article-content h2,
+.article-content h3 {
+  margin-top: 2.5rem;
+  color: #0d1b2a;
+}
+
+.policy-section p,
+.article-content p,
+.article-content li {
+  line-height: 1.8;
+  color: #2f2f2f;
+}
+
+.policy-section .last-updated,
+.article-meta {
+  margin-top: 2rem;
+  font-size: 0.95rem;
+  color: #5a6b7b;
+}
+
+.contact-detail .container.split {
+  align-items: flex-start;
+}
+
+.contact-detail .contact-info-card,
+.contact-detail .contact-form-card {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 2.5rem;
+  box-shadow: 0 18px 45px -30px rgba(13, 27, 42, 0.5);
+}
+
+.contact-detail .contact-info-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.contact-detail .contact-details {
+  display: grid;
+  gap: 1rem;
+}
+
+.contact-detail .contact-details .label {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #5a6b7b;
+}
+
+.contact-detail .contact-details a {
+  color: #0d1b2a;
+  font-weight: 600;
+}
+
+.contact-detail .service-areas {
+  border-top: 1px solid rgba(13, 27, 42, 0.08);
+  padding-top: 1.5rem;
+}
+
+.contact-detail .field-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.contact-detail label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 500;
+  color: #0d1b2a;
+}
+
+.contact-detail input,
+.contact-detail select,
+.contact-detail textarea {
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(13, 27, 42, 0.2);
+  border-radius: 10px;
+  font-family: 'Work Sans', sans-serif;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.contact-detail input:focus,
+.contact-detail select:focus,
+.contact-detail textarea:focus {
+  border-color: #5173f1;
+  box-shadow: 0 0 0 3px rgba(81, 115, 241, 0.2);
+  outline: none;
+}
+
+.map-section .map-placeholder {
+  margin-top: 2rem;
+  background: repeating-linear-gradient(
+      45deg,
+      rgba(13, 27, 42, 0.08),
+      rgba(13, 27, 42, 0.08) 10px,
+      rgba(13, 27, 42, 0.04) 10px,
+      rgba(13, 27, 42, 0.04) 20px
+    );
+  border-radius: 18px;
+  padding: 5rem 2rem;
+  text-align: center;
+  color: #3a4d63;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.map-section .map-placeholder span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 999px;
+}
+
+.blog-listing .articles-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 2rem;
+}
+
+.blog-card {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: 0 18px 45px -28px rgba(13, 27, 42, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.blog-card h3 {
+  font-size: 1.35rem;
+  line-height: 1.4;
+  color: #0d1b2a;
+}
+
+.blog-card p {
+  color: #2f2f2f;
+  line-height: 1.7;
+}
+
+.blog-card a {
+  margin-top: auto;
+  font-weight: 600;
+  color: #5173f1;
+}
+
+.article-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.95rem;
+}
+
+.article-content blockquote {
+  margin: 2.5rem 0;
+  padding: 1.5rem 2rem;
+  border-left: 4px solid #5173f1;
+  background: rgba(81, 115, 241, 0.08);
+  font-style: italic;
+  color: #1f2c3f;
+}
+
+.article-content ul,
+.article-content ol {
+  margin: 1.5rem 0;
+  padding-left: 1.5rem;
+}
+
+.article-content li {
+  margin-bottom: 0.75rem;
+}
+
+.cookie-banner {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: -100%;
+  background: rgba(13, 27, 42, 0.98);
+  color: #ffffff;
+  z-index: 999;
+  transition: bottom 0.4s ease;
+  padding: 1.25rem 0;
+  font-size: 0.95rem;
+}
+
+.cookie-banner.is-visible {
+  bottom: 0;
+}
+
+.cookie-banner__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cookie-banner p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.cookie-banner a {
+  color: #a9c1ff;
+  font-weight: 600;
+}
+
+.cookie-banner .btn {
+  align-self: flex-start;
+}
+
+@media (max-width: 1024px) {
+  .blog-listing .articles-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .page-hero,
+  .blog-hero,
+  .article-hero {
+    padding: 4.5rem 0 2.5rem;
+  }
+
+  .contact-detail .container.split {
+    grid-template-columns: 1fr;
+  }
+
+  .contact-detail .field-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .map-section .map-placeholder {
+    padding: 4rem 1.5rem;
+  }
+
+  .blog-listing .articles-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .cookie-banner {
+    padding: 1.5rem 0;
+  }
+
+  .cookie-banner__inner {
+    align-items: stretch;
+  }
+
+  .cookie-banner .btn {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,78 @@
+const navToggle = document.getElementById('nav-toggle');
+const siteNav = document.getElementById('site-nav');
+const yearEl = document.getElementById('year');
+
+if (navToggle && siteNav) {
+  navToggle.addEventListener('click', () => {
+    siteNav.classList.toggle('open');
+    navToggle.classList.toggle('active');
+  });
+}
+
+if (navToggle) {
+  navToggle.addEventListener('click', () => {
+    const spans = navToggle.querySelectorAll('span');
+    if (navToggle.classList.contains('active')) {
+      spans.forEach((span, idx) => {
+        span.style.transform =
+          idx === 0
+            ? 'translateY(8px) rotate(45deg)'
+            : idx === 1
+            ? 'scaleX(0)'
+            : 'translateY(-8px) rotate(-45deg)';
+        span.style.opacity = idx === 1 ? '0' : '1';
+      });
+    } else {
+      spans.forEach((span) => {
+        span.style.transform = 'none';
+        span.style.opacity = '1';
+      });
+    }
+  });
+}
+
+if (siteNav) {
+  siteNav.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => {
+      siteNav.classList.remove('open');
+      if (navToggle) {
+        navToggle.classList.remove('active');
+        navToggle.querySelectorAll('span').forEach((span) => {
+          span.style.transform = 'none';
+          span.style.opacity = '1';
+        });
+      }
+    });
+  });
+}
+
+if (yearEl) {
+  yearEl.textContent = new Date().getFullYear();
+}
+
+const cookieBanner = document.getElementById('cookie-banner');
+const cookieAccept = document.getElementById('cookie-accept');
+const cookieConsentKey = 'jk_cookie_consent';
+
+if (cookieBanner && cookieAccept) {
+  let hasConsent = null;
+
+  try {
+    hasConsent = window.localStorage.getItem(cookieConsentKey);
+  } catch (err) {
+    hasConsent = null;
+  }
+
+  if (!hasConsent) {
+    cookieBanner.classList.add('is-visible');
+  }
+
+  cookieAccept.addEventListener('click', () => {
+    try {
+      window.localStorage.setItem(cookieConsentKey, 'accepted');
+    } catch (err) {
+      // Ignore storage errors and simply hide the banner.
+    }
+    cookieBanner.classList.remove('is-visible');
+  });
+}

--- a/blog/building-strong-trucking-case.html
+++ b/blog/building-strong-trucking-case.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Essential Steps After a Serious Trucking Accident | James B. Kennedy, Jr.</title>
+    <meta
+      name="description"
+      content="A detailed 1,500-word article outlining how attorney James B. Kennedy, Jr. builds high-stakes trucking accident cases through rapid response and federal compliance analysis."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600&family=Work+Sans:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/css/styles.css" />
+  </head>
+  <body class="interior-page">
+    <header class="site-header">
+      <div class="container">
+        <div class="branding">
+          <div class="logo">JK</div>
+          <div class="identity">
+            <span class="name">James B. Kennedy, Jr.</span>
+            <span class="tagline">Personal Injury Trial Lawyer</span>
+          </div>
+        </div>
+        <a class="cta-pill" href="tel:9155445200">Call 915-544-5200</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="article-hero">
+        <div class="container narrow">
+          <p class="eyebrow">Commercial Vehicle Litigation</p>
+          <h1>Essential Steps After a Serious Trucking Accident</h1>
+          <div class="article-meta">
+            <span>By James B. Kennedy, Jr.</span>
+            <span>Board-Certified in Personal Injury Trial Law</span>
+            <span>Approx. 1,500 words</span>
+          </div>
+        </div>
+      </section>
+
+      <article class="article-content">
+        <div class="container narrow">
+          <p>
+            Catastrophic trucking collisions differ from typical car crashes in scale, complexity, and
+            urgency. The forces involved are massive, the injuries life-altering, and the corporate
+            defendants highly motivated to limit exposure. Within hours of an 18-wheeler crash, motor
+            carriers dispatch rapid response teams that include safety directors, defense lawyers, and
+            insurance adjusters. Their mission is to control the scene, gather favorable evidence, and
+            prepare defenses before injured people can seek counsel. As a trial lawyer who has litigated
+            trucking cases across Texas, New Mexico, Colorado, Arizona, and Nevada, I know that victims
+            must respond just as quickly. This article outlines the essential steps we take to preserve
+            evidence, expose regulatory violations, and hold negligent trucking companies accountable.
+          </p>
+
+          <h2>Activate an Experienced Legal Team Immediately</h2>
+          <p>
+            Time is the most precious resource after a trucking crash. I encourage families to contact a
+            lawyer as soon as emergency medical needs are stabilized. Our firm mobilizes investigators,
+            accident reconstructionists, and trucking experts to visit the scene, photograph debris,
+            capture skid marks, and secure physical evidence before it is lost. We send preservation
+            letters to the motor carrier and any brokers or shippers involved, demanding that driver logs,
+            electronic control module (ECM) data, satellite tracking information, and vehicle components be
+            retained. Taking swift action ensures that critical information is not destroyed or altered by
+            a corporate defense team hoping to escape responsibility.
+          </p>
+          <p>
+            Coordinating with local law enforcement and the Department of Public Safety can provide
+            valuable insights. Officers may have conducted post-crash inspections, noted equipment
+            violations, or collected witness statements that support our case. We obtain these reports and
+            request supplemental materials, such as body-camera footage or photographs. When necessary, we
+            hire private investigators to canvass nearby businesses for surveillance video or interview
+            witnesses who were not identified at the scene. Leaving no stone unturned in the first days and
+            weeks sets the tone for the entire litigation process.
+          </p>
+
+          <h2>Secure and Analyze Electronic Data</h2>
+          <p>
+            Modern commercial trucks generate vast amounts of electronic data. The ECM, commonly known as
+            the "black box," records speed, brake application, engine RPMs, and diagnostic codes leading up
+            to a crash. Advanced telematics systems capture GPS positions, driver behavior, and maintenance
+            alerts. Many fleets rely on dash cameras or inward-facing video that documents driver fatigue,
+            distraction, or noncompliance with safety policies. We work with forensic experts to download
+            this information in a forensically sound manner, preserving metadata and ensuring admissibility
+            in court. The data often reveals crucial facts that contradict the driver’s account or expose
+            systemic safety failures.
+          </p>
+          <p>
+            When motor carriers delay or refuse to produce data, we seek court orders compelling
+            preservation and production. Federal Motor Carrier Safety Administration (FMCSA) regulations
+            require carriers to maintain driver qualification files, hours-of-service logs, and inspection
+            records. Violations can lead to sanctions and strengthen negligence per se claims. By studying
+            electronic data alongside paper records, we identify patterns of over-hours driving, falsified
+            logs, and inadequate maintenance that contributed to the collision. These findings become
+            powerful leverage during settlement negotiations and compelling evidence at trial.
+          </p>
+
+          <h2>Investigate the Driver and Motor Carrier</h2>
+          <p>
+            A thorough background investigation of the driver and employer is indispensable. We examine the
+            driver’s qualification file, which should include employment history, drug and alcohol testing,
+            medical certifications, and training records. Warning signs such as prior crashes, moving
+            violations, or hours-of-service violations indicate that the carrier ignored red flags. We
+            scrutinize hiring practices to determine whether the company performed required background checks
+            or contacted previous employers. Patterns of noncompliance demonstrate negligent hiring,
+            retention, or entrustment.
+          </p>
+          <p>
+            Motor carriers have a duty to implement safety policies, monitor compliance, and discipline
+            drivers who cut corners. We request safety manuals, dispatch procedures, and disciplinary
+            records. If the company incentivized unrealistic delivery schedules or failed to enforce rest
+            periods, it can be held liable for corporate negligence. Publicly available FMCSA data provides
+            insight into the carrier’s safety rating, prior violations, and crash history. Comparing our case
+            to those statistics often reveals systemic problems that resonate with juries concerned about
+            highway safety.
+          </p>
+
+          <h2>Analyze the Role of Brokers, Shippers, and Maintenance Contractors</h2>
+          <p>
+            Trucking cases frequently involve more than just the driver and motor carrier. Freight brokers,
+            shippers, and maintenance contractors may share responsibility. Brokers who negligently hire unsafe
+            carriers or fail to vet safety records can be liable under negligent selection theories. Shippers
+            that improperly load cargo, fail to secure hazardous materials, or pressure carriers to violate
+            hours-of-service rules may also be culpable. Maintenance contractors who perform substandard work
+            on brakes, tires, or steering systems contribute to catastrophic failures.
+          </p>
+          <p>
+            Identifying all responsible parties expands available insurance coverage and ensures the jury hears
+            the full story of what went wrong. We examine contracts, dispatch communications, and bills of
+            lading to understand each entity’s role. Depositions of logistics coordinators, warehouse personnel,
+            and mechanics provide firsthand accounts of policies and practices. Building a multi-faceted case
+            underscores that trucking safety is a shared responsibility across the supply chain.
+          </p>
+
+          <h2>Document the Client’s Injuries and Life Changes</h2>
+          <p>
+            Truck crashes cause devastating injuries: traumatic brain injuries, spinal cord damage, crushed
+            limbs, burns, and wrongful deaths. While investigating liability, we devote equal attention to the
+            client’s medical journey. Working with treating physicians, rehabilitation specialists, and life-
+            care planners, we document surgeries, hospitalizations, therapies, and adaptive equipment needs. We
+            collect narratives from family members describing caregiving responsibilities, emotional trauma, and
+            the daily adjustments required. These stories make the damages portion of the case vivid and human.
+          </p>
+          <p>
+            Economic experts analyze lost wages, diminished earning capacity, and future medical expenses.
+            Vocational rehabilitation specialists evaluate how permanent impairments affect employment options.
+            Day-in-the-life videos and photo essays show jurors the full scope of the injury’s impact. Because
+            trucking companies often have substantial insurance policies, they vigorously contest damages. Our
+            goal is to present an irrefutable picture of what the client has endured and what they will need to
+            move forward with dignity.
+          </p>
+
+          <h2>Leverage Federal Regulations and Industry Standards</h2>
+          <p>
+            The FMCSA regulations set minimum safety standards for commercial carriers. Demonstrating violations
+            of these rules establishes negligence per se and highlights the carrier’s disregard for public safety.
+            We analyze hours-of-service compliance, driver qualification requirements, vehicle inspection mandates,
+            and hazardous materials rules. Industry standards from the Commercial Vehicle Safety Alliance,
+            American Trucking Associations, or National Transportation Safety Board provide additional benchmarks.
+            When a company falls below these norms, it signals to jurors that cost-cutting took precedence over
+            human life.
+          </p>
+          <p>
+            Expert testimony is instrumental in translating regulations into compelling evidence. Former safety
+            directors, trucking consultants, and human-factors specialists explain how proper policies could have
+            prevented the crash. Demonstratives such as logbook timelines, 3D animations, or route maps bring the
+            regulations to life. By grounding the case in federal law and industry best practices, we show that
+            the defendant’s conduct was not an isolated mistake but a fundamental breach of duty.
+          </p>
+
+          <h2>Prepare for Aggressive Defense Tactics</h2>
+          <p>
+            Trucking defense teams are sophisticated. They may argue that a sudden emergency, weather conditions,
+            or a third-party driver caused the crash. They often challenge causation, claiming that preexisting
+            conditions or prior injuries explain the client’s symptoms. Some attempt to shift blame onto the
+            plaintiff by highlighting moments of inattention. We combat these tactics with meticulous preparation.
+            Depositions of the driver, safety director, and corporate representatives reveal inconsistencies and
+            expose efforts to avoid responsibility. Motion practice enforces discovery obligations and excludes
+            improper defenses.
+          </p>
+          <p>
+            We also anticipate surveillance, social media monitoring, and sub rosa investigations aimed at
+            undermining credibility. Coaching clients on privacy, honesty, and consistent medical follow-up keeps
+            the defense from exploiting perceived gaps. Mock trials and focus groups test how jurors respond to
+            defense themes, allowing us to refine our storytelling before trial. By expecting aggressive tactics,
+            we stay one step ahead.
+          </p>
+
+          <h2>Pursue Punitive Damages When Warranted</h2>
+          <p>
+            In egregious cases, punitive damages may be available to punish and deter reckless conduct. Examples
+            include falsifying logbooks to conceal chronic fatigue, ignoring repeated safety violations, or
+            operating vehicles with knowingly defective brakes. Pursuing punitive damages requires clear and
+            convincing evidence of gross negligence. We gather internal emails, safety audits, and witness
+            testimony demonstrating conscious indifference to the safety of others. Presenting this evidence not
+            only increases potential recovery but also sends a message that the community will not tolerate
+            dangerous trucking practices.
+          </p>
+          <p>
+            Seeking punitive damages influences settlement negotiations by increasing the defendant’s risk. Even if
+            punitive claims ultimately resolve before trial, the discovery process needed to support them often
+            uncovers additional negligence that benefits the compensatory case. Holding companies accountable for
+            reckless decisions makes highways safer for everyone.
+          </p>
+
+          <h2>Resolution Through Settlement or Trial</h2>
+          <p>
+            Many trucking cases settle after extensive discovery, particularly when the evidence of negligence is
+            overwhelming. Mediation can be productive once both sides understand the risks of trial. We enter
+            negotiation settings with comprehensive presentations that include liability exhibits, medical
+            summaries, and life-care plans. However, we never assume settlement is guaranteed. Preparing for trial
+            from day one ensures that if negotiations fail, we can present a compelling case to a jury.
+          </p>
+          <p>
+            At trial, we focus on telling a story of corporate choices and community safety. Jurors respond when
+            they understand that their verdict can influence future conduct. We highlight the human stakes, the
+            preventability of the crash, and the dignity of our client. Whether the case resolves in the courtroom
+            or at the negotiating table, the disciplined steps outlined above maximize the opportunity for full and
+            fair compensation.
+          </p>
+
+          <h2>Conclusion</h2>
+          <p>
+            Serious trucking accidents require a rapid, coordinated response that matches the resources of the
+            trucking company and its insurers. By mobilizing investigators, preserving electronic data,
+            scrutinizing corporate practices, documenting life-changing injuries, and invoking federal regulations,
+            we hold negligent carriers accountable. Each case is an opportunity to deliver justice for the injured
+            and to push the industry toward safer practices. Families facing the aftermath of a trucking crash do
+            not have to confront it alone; with experienced counsel, they can uncover the truth and fight for the
+            resources needed to rebuild their lives.
+          </p>
+        </div>
+      </article>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>&copy; <span id="year"></span> James Kennedy, P.L.L.C. All rights reserved.</p>
+        <div class="footer-links">
+          <a href="../index.html#about">About</a>
+          <a href="../index.html#practice-areas">Practice Areas</a>
+          <a href="index.html">Blog</a>
+          <a href="../contact.html">Contact</a>
+          <a href="../privacy-policy.html">Privacy Policy</a>
+          <a href="../disclaimer.html">Disclaimer</a>
+        </div>
+      </div>
+    </footer>
+
+    <div class="cookie-banner" id="cookie-banner" role="dialog" aria-live="polite">
+      <div class="container cookie-banner__inner">
+        <p>
+          This website uses cookies to analyze site traffic and improve your experience. By
+          clicking “Accept,” you consent to the use of cookies in accordance with our
+          <a href="../privacy-policy.html">Privacy Policy</a>.
+        </p>
+        <button class="btn primary" id="cookie-accept" type="button">Accept</button>
+      </div>
+    </div>
+
+    <script src="../assets/js/main.js"></script>
+  </body>
+</html>

--- a/blog/catastrophic-injury-damages.html
+++ b/blog/catastrophic-injury-damages.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Calculating Damages in Catastrophic Injury Cases | James B. Kennedy, Jr.</title>
+    <meta
+      name="description"
+      content="A 1,500-word exploration by James B. Kennedy, Jr. on evaluating economic and non-economic damages in catastrophic injury and wrongful death cases."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600&family=Work+Sans:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/css/styles.css" />
+  </head>
+  <body class="interior-page">
+    <header class="site-header">
+      <div class="container">
+        <div class="branding">
+          <div class="logo">JK</div>
+          <div class="identity">
+            <span class="name">James B. Kennedy, Jr.</span>
+            <span class="tagline">Personal Injury Trial Lawyer</span>
+          </div>
+        </div>
+        <a class="cta-pill" href="tel:9155445200">Call 915-544-5200</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="article-hero">
+        <div class="container narrow">
+          <p class="eyebrow">Damages &amp; Recovery</p>
+          <h1>Calculating Damages in Catastrophic Injury Cases</h1>
+          <div class="article-meta">
+            <span>By James B. Kennedy, Jr.</span>
+            <span>Advocating for Full Compensation</span>
+            <span>Approx. 1,500 words</span>
+          </div>
+        </div>
+      </section>
+
+      <article class="article-content">
+        <div class="container narrow">
+          <p>
+            Catastrophic injury cases demand meticulous attention to the damages component of a lawsuit. Unlike
+            minor collision claims where medical bills and vehicle repairs dominate the conversation, life-altering
+            injuries touch every aspect of a person’s existence. Calculating damages becomes an exercise in honoring
+            the client’s story, ensuring long-term needs are met, and conveying the magnitude of loss to adjusters,
+            judges, and juries. Having represented clients with traumatic brain injuries, spinal cord damage, severe
+            burns, amputations, and wrongful death losses across Texas and the Southwest, I have seen how a carefully
+            constructed damages case can transform the outcome. The following guide walks through the categories of
+            damages and the strategies we employ to present them persuasively.
+          </p>
+
+          <h2>Start with Comprehensive Medical Documentation</h2>
+          <p>
+            The medical record is the backbone of any catastrophic injury case. We gather hospital records, surgical
+            reports, diagnostic imaging, and therapy notes to demonstrate the severity of the trauma. Complex injuries
+            often involve long stays in intensive care, multiple surgeries, and extended rehabilitation. We work closely
+            with treating physicians to ensure the records clearly link the injuries to the incident and outline the
+            prognosis. When clients require specialized care from neurologists, orthopedic surgeons, or burn units, we
+            obtain detailed reports describing the procedures performed and the expected recovery timeline.
+          </p>
+          <p>
+            Medical chronologies help distill thousands of pages of records into accessible summaries for adjusters and
+            juries. We highlight key events, such as emergent surgeries, complications, and transitions to rehabilitation.
+            These chronologies also identify gaps in care that require clarification. When insurers question causation or
+            necessity, we seek affidavits from treating physicians attesting to the reasonableness of treatment. By
+            presenting a cohesive medical narrative, we lay the foundation for every other damages category.
+          </p>
+
+          <h2>Quantify Past and Future Medical Expenses</h2>
+          <p>
+            Catastrophic injuries generate significant medical bills. We collect itemized statements from hospitals,
+            physicians, therapists, pharmacies, and medical equipment providers. Many clients face balance billing issues
+            when their health insurance or Medicare payments do not cover the full charges. We document these outstanding
+            balances, negotiate liens where possible, and include them in the damages calculation.
+          </p>
+          <p>
+            Future medical expenses require expert analysis. Life-care planners interview the client, consult with
+            treating providers, and review medical literature to estimate lifelong needs. Their plans consider attendant
+            care, home health services, adaptive equipment, medication regimens, transportation modifications, and
+            architectural changes to the home. For spinal cord injury clients, for example, a plan may include power
+            wheelchairs, pressure-relief mattresses, accessible vans, and ongoing therapy. We collaborate with economists
+            to convert these costs into present value, accounting for inflation and life expectancy. Presenting a
+            detailed, data-driven life-care plan demonstrates the economic reality of living with a catastrophic injury.
+          </p>
+
+          <h2>Address Lost Income and Diminished Earning Capacity</h2>
+          <p>
+            Many catastrophic injuries prevent clients from returning to their prior careers. We gather employment
+            records, W-2s, tax returns, and benefits statements to calculate past lost wages. Employers can provide
+            documentation of missed promotions, lost bonuses, or reduced hours. For self-employed clients, we analyze
+            business records, profit-and-loss statements, and contracts to show how the injury impacted revenue.
+          </p>
+          <p>
+            Diminished earning capacity accounts for the difference between what the client would have earned absent the
+            injury and what they can earn moving forward. Vocational experts assess transferable skills, labor market
+            conditions, and the feasibility of retraining. Economists then project lifetime earnings, incorporating
+            wage growth, retirement age, and fringe benefits. In wrongful death cases, we calculate the decedent’s
+            expected earnings and the portion of income that would have supported dependents. Presenting these analyses in
+            clear charts and tables helps jurors grasp the magnitude of financial loss.
+          </p>
+
+          <h2>Capture Household Services and Caregiving Costs</h2>
+          <p>
+            Catastrophic injuries often require extensive caregiving. Spouses, parents, or adult children may leave jobs
+            or reduce hours to provide daily assistance. We document these contributions through testimony and care logs.
+            If the family hires professional caregivers, we gather invoices and contracts. Even when relatives provide
+            unpaid care, Texas law recognizes the value of those services. We calculate the cost of replacing family care
+            with professional assistance, reinforcing the economic impact of the injury.
+          </p>
+          <p>
+            Household services also extend beyond personal care. Clients may need help with cooking, cleaning, yard work,
+            childcare, and vehicle maintenance. These tasks carry real value, especially when the injured person previously
+            contributed significantly to household operations. Demonstrating how the injury shifted responsibilities within
+            the family paints a vivid picture of the disruption.
+          </p>
+
+          <h2>Demonstrate Physical Pain and Emotional Suffering</h2>
+          <p>
+            Non-economic damages capture the human cost of catastrophic injury. Pain and suffering encompass acute
+            physical pain, chronic discomfort, and the emotional toll of living with limitations. We encourage clients to
+            maintain journals describing daily experiences, medications taken, side effects, and emotional challenges. Pain
+            specialists and psychologists can provide testimony explaining how the injuries affect sleep, mobility, mood,
+            and relationships. Jurors connect with specific examples: the inability to pick up a child, the frustration of
+            relearning basic tasks, or the fear of future surgeries.
+          </p>
+          <p>
+            Emotional distress encompasses anxiety, depression, post-traumatic stress disorder, and grief. Catastrophic
+            injuries often trigger identity crises as clients grapple with changed abilities. We collaborate with mental
+            health professionals to document diagnoses, treatment plans, and prognosis. Group therapy, counseling, and
+            medication regimens demonstrate proactive efforts to cope. Sharing these experiences respectfully helps jurors
+            appreciate the profound adjustments required.
+          </p>
+
+          <h2>Address Physical Impairment and Disfigurement</h2>
+          <p>
+            Texas law allows separate recovery for physical impairment and disfigurement. Physical impairment focuses on
+            the loss of the ability to engage in life’s activities. A former athlete who can no longer compete, a nurse who
+            cannot stand for long shifts, or a parent unable to play with children experiences a significant impairment.
+            We gather testimony from friends, coworkers, and community members to illustrate these losses.
+          </p>
+          <p>
+            Disfigurement encompasses visible scars, amputations, or burns that alter appearance. Plastic surgeons and
+            dermatologists can explain whether future procedures might improve appearance or whether the changes are
+            permanent. High-resolution photographs, taken respectfully and with consent, help jurors comprehend the
+            lasting impact. These damages recognize that appearance influences self-esteem, social interactions, and
+            quality of life.
+          </p>
+
+          <h2>Account for Loss of Consortium and Companionship</h2>
+          <p>
+            Catastrophic injuries reverberate through families. Spouses may experience a loss of intimacy, shared
+            activities, and emotional partnership. Children may miss the guidance, mentoring, or playtime that defined
+            their relationship with a parent. In wrongful death cases, surviving family members grapple with profound loss
+            of companionship. We handle these claims with sensitivity, encouraging family members to share stories that
+            capture the essence of their relationships before and after the incident. Jurors respond to genuine, heartfelt
+            testimony that underscores the irreplaceable nature of these bonds.
+          </p>
+
+          <h2>Consider Punitive Damages When Conduct Is Egregious</h2>
+          <p>
+            Some catastrophic injury cases stem from reckless or grossly negligent conduct. Examples include drunk driving,
+            knowingly defective products, or companies that ignore safety regulations. In these instances, Texas law allows
+            punitive damages to punish wrongdoers and deter similar behavior. Pursuing punitive damages requires clear and
+            convincing evidence, so we gather internal documents, prior incident reports, and expert testimony to
+            demonstrate conscious indifference. While punitive damages are not available in every case, asserting them when
+            justified signals to defendants that the community will not tolerate dangerous conduct.
+          </p>
+
+          <h2>Use Demonstrative Exhibits to Tell the Story</h2>
+          <p>
+            Visual aids play a powerful role in communicating damages. Day-in-the-life videos show the daily realities of
+            therapy, caregiving, and adaptive devices. Medical illustrations explain surgical procedures or the mechanics of
+            injuries. Economic charts translate complex calculations into digestible graphics. Interactive timelines chart
+            the recovery journey, highlighting milestones and setbacks. These exhibits make abstract concepts tangible and
+            keep jurors engaged.
+          </p>
+          <p>
+            Technology also enables immersive presentations. 3D modeling can recreate crash scenes or demonstrate how a
+            product failed. Virtual reality experiences, used responsibly, allow jurors to understand the client’s limited
+            mobility. Regardless of the format, demonstratives should align with the narrative crafted through witness
+            testimony. Consistency ensures that every element reinforces the same message.
+          </p>
+
+          <h2>Prepare Clients and Witnesses for Testimony</h2>
+          <p>
+            Effective damages presentations depend on credible, prepared witnesses. We spend significant time coaching
+            clients on how to share their stories authentically without exaggeration. Practicing direct and cross-
+            examination questions builds confidence. We also prepare family members, coworkers, and experts to focus on
+            specific themes. Authentic emotion resonates with jurors when supported by facts. Honesty about challenges,
+            resilience, and ongoing hope for recovery reflects the complexity of living with catastrophic injury.
+          </p>
+          <p>
+            Preparing witnesses includes addressing difficult topics. Clients may feel embarrassed discussing incontinence,
+            sexual dysfunction, or mental health struggles. We create a supportive environment that allows them to speak
+            candidly while maintaining dignity. Addressing these realities head-on prevents the defense from exploiting
+            them later and ensures the jury hears the full scope of harm.
+          </p>
+
+          <h2>Collaborate with Financial Professionals After Settlement</h2>
+          <p>
+            Resolving a catastrophic injury case is not the end of the journey. Structured settlements, special needs
+            trusts, and investment strategies help protect the recovery. We collaborate with financial planners and trust
+            attorneys to tailor solutions to each client’s circumstances. For minors or clients with cognitive impairments,
+            guardianship arrangements and court approvals may be necessary. Addressing these issues proactively ensures the
+            recovery lasts and supports long-term independence.
+          </p>
+          <p>
+            We also negotiate healthcare liens and subrogation claims to maximize the net recovery. Medicare, Medicaid, and
+            ERISA plans impose strict requirements, and compliance prevents future disputes. Clients appreciate guidance on
+            these complex issues, especially when they are focused on healing rather than paperwork.
+          </p>
+
+          <h2>Conclusion</h2>
+          <p>
+            Calculating damages in catastrophic injury cases is both an art and a science. It requires careful analysis of
+            economic losses, compassionate storytelling, and relentless attention to detail. By documenting medical care,
+            projecting future needs, quantifying lost income, valuing household contributions, and honoring non-economic
+            harms, we present a full picture of the client’s losses. Each element reinforces the central truth: catastrophic
+            injuries reshape lives, and the civil justice system exists to provide the resources necessary for recovery.
+            With a comprehensive damages strategy, injured individuals and their families can pursue accountability and
+            rebuild with dignity.
+          </p>
+        </div>
+      </article>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>&copy; <span id="year"></span> James Kennedy, P.L.L.C. All rights reserved.</p>
+        <div class="footer-links">
+          <a href="../index.html#about">About</a>
+          <a href="../index.html#practice-areas">Practice Areas</a>
+          <a href="index.html">Blog</a>
+          <a href="../contact.html">Contact</a>
+          <a href="../privacy-policy.html">Privacy Policy</a>
+          <a href="../disclaimer.html">Disclaimer</a>
+        </div>
+      </div>
+    </footer>
+
+    <div class="cookie-banner" id="cookie-banner" role="dialog" aria-live="polite">
+      <div class="container cookie-banner__inner">
+        <p>
+          This website uses cookies to analyze site traffic and improve your experience. By
+          clicking “Accept,” you consent to the use of cookies in accordance with our
+          <a href="../privacy-policy.html">Privacy Policy</a>.
+        </p>
+        <button class="btn primary" id="cookie-accept" type="button">Accept</button>
+      </div>
+    </div>
+
+    <script src="../assets/js/main.js"></script>
+  </body>
+</html>

--- a/blog/comparative-negligence-texas.html
+++ b/blog/comparative-negligence-texas.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Understanding Comparative Negligence in Texas | James B. Kennedy, Jr.</title>
+    <meta
+      name="description"
+      content="Trial lawyer James B. Kennedy, Jr. breaks down Texas comparative negligence rules in this 1,500-word article for injury victims and their families."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600&family=Work+Sans:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/css/styles.css" />
+  </head>
+  <body class="interior-page">
+    <header class="site-header">
+      <div class="container">
+        <div class="branding">
+          <div class="logo">JK</div>
+          <div class="identity">
+            <span class="name">James B. Kennedy, Jr.</span>
+            <span class="tagline">Personal Injury Trial Lawyer</span>
+          </div>
+        </div>
+        <a class="cta-pill" href="tel:9155445200">Call 915-544-5200</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="article-hero">
+        <div class="container narrow">
+          <p class="eyebrow">Texas Liability Rules</p>
+          <h1>Understanding Comparative Negligence in Texas</h1>
+          <div class="article-meta">
+            <span>By James B. Kennedy, Jr.</span>
+            <span>Board-Certified Personal Injury Trial Lawyer</span>
+            <span>Approx. 1,500 words</span>
+          </div>
+        </div>
+      </section>
+
+      <article class="article-content">
+        <div class="container narrow">
+          <p>
+            Few questions cause more confusion after a serious accident than how fault affects compensation. Texas uses a
+            modified comparative negligence system that balances accountability with fairness. Injured people can still
+            recover damages even if they played a limited role in the incident, but their recovery may be reduced according
+            to their percentage of responsibility. Understanding how this system works is essential for making informed
+            decisions after a crash, workplace incident, or other traumatic event. This article explains Texas’s
+            proportionate responsibility framework, how insurance companies leverage it, and what strategies protect your
+            claim.
+          </p>
+
+          <h2>The Basics of Texas Comparative Negligence</h2>
+          <p>
+            Texas follows a 51 percent bar rule for comparative negligence, codified in Chapter 33 of the Texas Civil
+            Practice and Remedies Code. Under this system, a plaintiff can recover damages as long as they are 50 percent or
+            less responsible for the incident. If the plaintiff is 51 percent or more at fault, they are barred from
+            recovering any damages from other parties. Within the allowable range, the court reduces the award by the
+            plaintiff’s percentage of fault. For example, if a jury determines total damages are $1,000,000 and assigns the
+            plaintiff 20 percent responsibility, the recoverable amount becomes $800,000. This structure encourages all
+            parties to act carefully while still compensating those harmed primarily by another’s negligence.
+          </p>
+          <p>
+            Comparative negligence applies to a wide range of cases, including motor vehicle collisions, premises liability,
+            product defects, workplace incidents, and professional negligence. Juries allocate fault among all responsible
+            parties, including defendants, plaintiffs, and sometimes third parties who are not present in the courtroom. The
+            verdict form typically lists each actor so jurors can assign percentages that total 100. Understanding how juries
+            make these decisions informs our litigation strategies.
+          </p>
+
+          <h2>How Insurance Companies Use Comparative Fault</h2>
+          <p>
+            Insurance adjusters quickly analyze whether they can attribute some blame to the claimant. Even minor allegations
+            of distraction, speeding, or failing to look both ways become tools to reduce settlement offers. Adjusters may
+            emphasize inconsistent statements or incomplete medical histories to question credibility. They know that every
+            percentage point assigned to the claimant directly reduces the payout. This is why recorded statements and early
+            interviews can be risky; casual comments are sometimes taken out of context to support a comparative negligence
+            defense.
+          </p>
+          <p>
+            In negotiations, adjusters often present charts showing hypothetical fault allocations and corresponding
+            settlement reductions. Without legal representation, claimants may feel pressured to accept these assumptions as
+            fact. Experienced trial lawyers counter by highlighting objective evidence, witness testimony, and expert
+            analysis demonstrating the defendant’s responsibility. We also remind insurers that if they overreach and a jury
+            perceives their tactics as unfair, the verdict may exceed settlement offers.
+          </p>
+
+          <h2>Gathering Evidence to Minimize Fault Allegations</h2>
+          <p>
+            A proactive investigation is the best defense against inflated comparative negligence claims. We secure accident
+            reports, surveillance footage, dash camera recordings, and electronic data from vehicles or machinery. Witness
+            statements gathered promptly carry more weight than recollections obtained months later. In premises liability
+            cases, maintenance logs, inspection records, and corporate policies reveal whether safety standards were
+            followed. In workplace incidents, OSHA reports and company training materials expose systemic issues.
+          </p>
+          <p>
+            Expert analysis strengthens the liability story. Accident reconstructionists, human-factors specialists, and
+            engineers explain how conditions, speeds, reaction times, or product designs contributed to the event. Medical
+            experts connect the injuries directly to the incident, dispelling claims that preexisting conditions are to
+            blame. When evidence shows that the defendant had superior knowledge, control, or ability to prevent the harm,
+            it becomes difficult for the defense to shift blame onto the injured party.
+          </p>
+
+          <h2>Handling Statements and Social Media</h2>
+          <p>
+            Anything an injured person says or posts can be used to argue comparative negligence. We advise clients to limit
+            conversations about the incident to their attorney, medical providers, and trusted loved ones. Social media posts
+            showing physical activity, travel, or statements about the crash may be misinterpreted. Even photos unrelated to
+            the injury can be taken out of context. Insurance companies routinely monitor public profiles and sometimes
+            obtain court orders for private content. Exercising caution preserves credibility.
+          </p>
+          <p>
+            When insurers request recorded statements, we prepare clients thoroughly or decline the request until litigation
+            begins. During depositions, we practice answering difficult questions truthfully without volunteering extra
+            information. Honesty and consistency are key; jurors understand that accidents are chaotic, and memories can be
+            imperfect. Owning small mistakes while emphasizing the defendant’s larger failures builds trust.
+          </p>
+
+          <h2>Addressing Comparative Negligence at Trial</h2>
+          <p>
+            Trial offers an opportunity to frame the comparative negligence issue on our terms. In opening statements, we
+            explain the law plainly: the jury must determine whether the defendant failed to act as a reasonably prudent
+            person and how that failure compares to the plaintiff’s conduct. We present evidence in a sequence that highlights
+            the defendant’s choices, safety violations, and control over the dangerous situation. Demonstrative exhibits
+            illustrate decision points where the defendant could have prevented harm but chose not to.
+          </p>
+          <p>
+            During cross-examination, we challenge attempts to exaggerate the plaintiff’s role. If the defense argues the
+            plaintiff was distracted, we ask whether the defendant also failed to maintain a proper lookout or follow safety
+            protocols. If the defense claims the plaintiff ignored warnings, we explore whether those warnings were adequate,
+            visible, and timely. Closing arguments reinforce that fairness requires holding the most responsible party
+            accountable. By the time jurors deliberate, they should see comparative negligence as a balanced, fact-driven
+            assessment rather than a tool for the defense to avoid accountability.
+          </p>
+
+          <h2>Special Considerations in Multi-Defendant Cases</h2>
+          <p>
+            Many catastrophic injury cases involve multiple defendants: drivers, employers, product manufacturers, property
+            owners, or contractors. Texas juries assign percentages of responsibility to each defendant, and each is liable
+            for its share of damages. However, when a defendant is more than 50 percent responsible, they may be jointly and
+            severally liable for the entire economic damages award. Understanding this threshold influences litigation
+            strategy. We often focus on the most culpable defendant to ensure the family can collect the full economic losses
+            even if other parties lack insurance or assets.
+          </p>
+          <p>
+            Multi-defendant cases also require careful jury charge preparation. We advocate for broad-form questions that
+            capture corporate negligence, negligent entrustment, and other theories so jurors can assign responsibility
+            accurately. We also guard against empty-chair defenses, where defendants blame non-parties to dilute their own
+            liability. Presenting evidence about non-party actors, when relevant, prevents the defense from rewriting the
+            story unchallenged.
+          </p>
+
+          <h2>The Impact on Settlement Negotiations</h2>
+          <p>
+            Comparative negligence influences settlement dynamics. Defendants who believe they can convince a jury the
+            plaintiff is primarily at fault may be less inclined to offer fair compensation. Demonstrating the strength of our
+            liability case through expert reports, witness statements, and motion practice helps shift leverage. When
+            mediation occurs, we address comparative negligence openly, using visuals and timelines to show why the
+            defendant’s conduct deserves the majority share of responsibility. Mediators appreciate candid assessments, and
+            jurors expect transparency.
+          </p>
+          <p>
+            We also remind insurers that juries respond to fairness. Overreaching on comparative negligence can backfire if
+            jurors perceive it as blaming the victim. By presenting a balanced, evidence-based narrative, we encourage
+            reasonable settlements while preserving the option of trial.
+          </p>
+
+          <h2>Using Jury Instructions to Clarify the Law</h2>
+          <p>
+            Long before closing arguments, we study the jury charge and propose instructions that explain comparative
+            negligence in approachable language. Drafting questions that mirror the facts of the case prevents confusion and
+            reduces the risk that jurors will speculate about legal standards. During trial, we reference those instructions
+            when examining witnesses, reinforcing how each decision point relates to the percentages the jury must assign. By
+            the time deliberations begin, jurors have heard the statutory framework multiple times and can apply it with
+            confidence.
+          </p>
+          <p>
+            We also prepare demonstratives that walk through sample calculations, illustrating how different allocations of
+            fault affect the ultimate award. Jurors appreciate transparency, and judges welcome efforts that keep the focus on
+            evidence rather than guesswork. When the defense attempts to distort the law, we return to the charge, highlighting
+            phrases that emphasize reasonableness, foreseeability, and the community’s standards of care. Empowering jurors
+            with clarity reduces the likelihood of compromise verdicts based on misunderstanding.
+          </p>
+
+          <h2>Empowering Clients Through Education</h2>
+          <p>
+            Clients often feel anxious when they hear they may share a small percentage of fault. We explain that this does
+            not derail their case. Understanding the law empowers clients to answer questions confidently and make informed
+            decisions about settlement. We discuss how everyday actions—such as seeking prompt medical care, following
+            treatment plans, and avoiding risky behaviors—reinforce the claim’s legitimacy. Education builds trust and keeps
+            clients engaged in the process.
+          </p>
+          <p>
+            Ultimately, comparative negligence reflects a community’s expectation that everyone acts responsibly. Our role is
+            to show how the defendant’s choices violated that expectation and caused harm that outweighs any minor missteps by
+            the injured person. With thorough preparation, honest storytelling, and strategic advocacy, injured Texans can
+            overcome comparative negligence defenses and secure the compensation they need to rebuild their lives.
+          </p>
+        </div>
+      </article>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>&copy; <span id="year"></span> James Kennedy, P.L.L.C. All rights reserved.</p>
+        <div class="footer-links">
+          <a href="../index.html#about">About</a>
+          <a href="../index.html#practice-areas">Practice Areas</a>
+          <a href="index.html">Blog</a>
+          <a href="../contact.html">Contact</a>
+          <a href="../privacy-policy.html">Privacy Policy</a>
+          <a href="../disclaimer.html">Disclaimer</a>
+        </div>
+      </div>
+    </footer>
+
+    <div class="cookie-banner" id="cookie-banner" role="dialog" aria-live="polite">
+      <div class="container cookie-banner__inner">
+        <p>
+          This website uses cookies to analyze site traffic and improve your experience. By
+          clicking “Accept,” you consent to the use of cookies in accordance with our
+          <a href="../privacy-policy.html">Privacy Policy</a>.
+        </p>
+        <button class="btn primary" id="cookie-accept" type="button">Accept</button>
+      </div>
+    </div>
+
+    <script src="../assets/js/main.js"></script>
+  </body>
+</html>

--- a/blog/expert-witnesses-personal-injury.html
+++ b/blog/expert-witnesses-personal-injury.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>The Role of Expert Witnesses in Injury Litigation | James B. Kennedy, Jr.</title>
+    <meta
+      name="description"
+      content="A 1,500-word article by James B. Kennedy, Jr. exploring how expert witnesses strengthen serious injury and wrongful death cases."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600&family=Work+Sans:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/css/styles.css" />
+  </head>
+  <body class="interior-page">
+    <header class="site-header">
+      <div class="container">
+        <div class="branding">
+          <div class="logo">JK</div>
+          <div class="identity">
+            <span class="name">James B. Kennedy, Jr.</span>
+            <span class="tagline">Personal Injury Trial Lawyer</span>
+          </div>
+        </div>
+        <a class="cta-pill" href="tel:9155445200">Call 915-544-5200</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="article-hero">
+        <div class="container narrow">
+          <p class="eyebrow">Expert Strategy</p>
+          <h1>The Role of Expert Witnesses in Injury Litigation</h1>
+          <div class="article-meta">
+            <span>By James B. Kennedy, Jr.</span>
+            <span>Trial Lawyer for the Seriously Injured</span>
+            <span>Approx. 1,500 words</span>
+          </div>
+        </div>
+      </section>
+
+      <article class="article-content">
+        <div class="container narrow">
+          <p>
+            Catastrophic injury and wrongful death cases frequently hinge on complex questions of science, engineering,
+            medicine, and economics. Jurors expect clear answers, yet the subject matter often lies far outside everyday
+            experience. Expert witnesses bridge that gap. They translate technical evidence into understandable insights,
+            validate the plaintiff’s theory of the case, and withstand cross-examination designed to sow doubt. Having tried
+            cases across Texas and the Southwest, I have seen the decisive impact that credible experts can make. This
+            article explores how we identify, prepare, and present expert witnesses to help juries see the truth.
+          </p>
+
+          <h2>Selecting the Right Experts for the Case</h2>
+          <p>
+            Every catastrophic injury case begins with a deep dive into the facts. Once we understand how the incident
+            occurred and the nature of the injuries, we determine which disciplines are necessary. In trucking cases, that
+            might include accident reconstructionists, trucking safety consultants, mechanical engineers, and life-care
+            planners. Product liability matters often require design engineers, metallurgists, and human-factors specialists.
+            Medical malpractice claims call for physicians in the same specialty as the defendant, along with nurses and
+            hospital administrators who understand standard operating procedures. Selecting experts with the right credentials
+            signals to jurors that the testimony is trustworthy.
+          </p>
+          <p>
+            We look beyond impressive resumes. A great expert must communicate effectively, teach jurors, and remain calm
+            under pressure. Courtroom presence matters. We review prior testimony, publications, and professional
+            associations. We also vet potential conflicts, ensuring the expert has no financial ties to the defendants. When
+            possible, we choose experts who have real-world experience, such as physicians who actively treat patients or
+            engineers who design similar equipment. Their ability to connect theory with practice resonates with jurors.
+          </p>
+
+          <h2>Establishing the Expert’s Foundation</h2>
+          <p>
+            Before an expert can testify, we must lay a foundation demonstrating their qualifications and the reliability of
+            their opinions. This involves creating a comprehensive expert file that includes curriculum vitae, publications,
+            prior testimony lists, and engagement agreements. We review relevant professional standards, peer-reviewed
+            literature, and regulatory requirements. Establishing this groundwork allows us to overcome Daubert challenges,
+            where the defense seeks to exclude testimony by arguing it is speculative or methodologically flawed.
+          </p>
+          <p>
+            We also ensure the expert has access to all pertinent case materials: medical records, photographs, surveillance
+            footage, incident reports, depositions, and discovery responses. Encouraging experts to identify additional
+            information they need fosters collaboration. When experts participate in inspections or testing, we document the
+            process meticulously to preserve admissibility. A strong foundation anticipates defense attacks and demonstrates
+            that the opinions rest on solid ground.
+          </p>
+
+          <h2>Collaborating to Shape Case Themes</h2>
+          <p>
+            Expert testimony should reinforce the core themes of the case. Early strategy sessions allow us to align legal
+            theories with technical explanations. For example, if our theme emphasizes a trucking company’s culture of
+            pushing drivers beyond legal limits, the safety expert can analyze hours-of-service data and corporate policies
+            to show systemic violations. In a product defect case centered on a missing guard, an engineer can explain how a
+            safer alternative design was feasible and widely known in the industry. Collaboration ensures each expert’s
+            testimony fits seamlessly into the larger narrative.
+          </p>
+          <p>
+            We also use experts to identify demonstrative exhibits. Engineers might suggest 3D models or cutaway views of
+            machinery. Medical experts can help create anatomical illustrations, surgical timelines, or day-in-the-life
+            videos. Economists prepare charts showing lost income projections or future care costs. These visuals make the
+            testimony engaging and help jurors retain key information.
+          </p>
+
+          <h2>Preparing Experts for Depositions and Trial</h2>
+          <p>
+            Defense attorneys will scrutinize every opinion, so preparation is essential. We conduct mock depositions to
+            simulate aggressive questioning. During these sessions, we emphasize clarity, avoiding jargon, and staying within
+            the scope of expertise. Experts practice explaining methodologies step-by-step, referencing exhibits, and handling
+            hypotheticals. When experts appear confident and composed, jurors are more likely to trust them.
+          </p>
+          <p>
+            Trial preparation involves rehearsing direct examination to highlight key points. We structure questions to tell a
+            story: who the expert is, what materials they reviewed, what methods they employed, and the conclusions they
+            reached. We discuss how to handle objections and pauses, ensuring the expert remains calm if the judge intervenes.
+            Preparing for cross-examination is equally important. We review potential weak spots, such as alternative
+            explanations or minor inconsistencies, and develop truthful, concise responses.
+          </p>
+
+          <h2>Using Experts to Address Causation</h2>
+          <p>
+            Causation is often the battleground of injury litigation. Medical experts connect the incident to the specific
+            injuries, explaining why symptoms align with trauma rather than preexisting conditions. They discuss diagnostic
+            imaging, lab results, and clinical observations. In cases involving traumatic brain injuries, neurologists and
+            neuropsychologists explain how cognitive deficits manifest in daily life.
+          </p>
+          <p>
+            Engineers and scientists address causation from a mechanical or environmental perspective. For example, a fire
+            investigator may demonstrate how a defective electrical component caused a blaze. A human-factors expert might
+            explain how poor warnings or interface design led to user error. Establishing causation through expert testimony
+            gives jurors the confidence to attribute responsibility where it belongs.
+          </p>
+
+          <h2>Demonstrating Damages with Expert Support</h2>
+          <p>
+            Damages testimony transforms abstract numbers into a roadmap for recovery. Life-care planners outline future
+            medical needs, detailing the cost of surgeries, therapies, medications, equipment, and home modifications.
+            Economists translate those needs into present value, accounting for inflation and life expectancy. Vocational
+            experts analyze how injuries affect employment prospects, while rehabilitation specialists describe the challenges
+            of returning to work.
+          </p>
+          <p>
+            Experts also play a role in illustrating non-economic damages. Psychologists describe the emotional impact of
+            trauma, including anxiety, depression, and post-traumatic stress disorder. Pain specialists explain chronic pain
+            mechanisms and the limitations imposed on daily activities. By presenting a holistic view of damages, experts help
+            jurors understand why full compensation is necessary.
+          </p>
+
+          <h2>Handling Defense Experts and Daubert Challenges</h2>
+          <p>
+            Anticipating the defense’s expert strategy is vital. We review opposing experts’ backgrounds, publications, and
+            prior testimony to uncover inconsistencies or biases. Depositions allow us to lock in their opinions and explore
+            methodological flaws. If an opposing expert relies on junk science, we file Daubert motions seeking exclusion.
+            Judges evaluate whether the testimony is based on reliable principles and methods. Success in these motions can
+            dramatically shift the balance of the case.
+          </p>
+          <p>
+            Even when a defense expert survives admissibility challenges, cross-examination can reveal weaknesses. We prepare
+            detailed outlines that compare their opinions to authoritative sources, highlight contradictions, and expose
+            financial incentives. Demonstrating that an opposing expert earns significant income testifying exclusively for
+            defendants, for example, can undermine credibility. Jurors appreciate transparency and fairness.
+          </p>
+
+          <h2>Presenting Expert Testimony Effectively at Trial</h2>
+          <p>
+            The order of expert witnesses matters. We often begin with liability experts to establish what went wrong, then
+            transition to medical and damages experts to show the consequences. Each witness builds on the previous one,
+            creating a logical progression. During direct examination, we use plain language and analogies to make complex
+            topics accessible. We also pace the testimony, pausing to display exhibits or play animations at critical moments.
+          </p>
+          <p>
+            Judges appreciate efficient presentations that respect jurors’ time. We avoid unnecessary repetition by ensuring
+            experts coordinate their topics. When multiple experts must address similar issues, we clarify the distinct
+            perspective each provides. Summaries at the end of each examination reinforce the key takeaways. In closing
+            argument, we weave expert testimony into the broader narrative, reminding jurors how each opinion supports the
+            verdict we seek.
+          </p>
+
+          <h2>Budgeting and Managing Expert Costs</h2>
+          <p>
+            High-quality expert testimony represents a significant investment. From initial case reviews to site inspections
+            and trial appearances, fees can escalate quickly. We create detailed budgets at the outset, tracking retainers,
+            hourly billing, and anticipated expenses for travel, testing, and demonstratives. Transparent communication with
+            clients about these costs fosters trust and ensures strategic decisions align with financial realities. When
+            possible, we stage work in phases so resources are deployed when they will have the greatest impact.
+          </p>
+          <p>
+            Effective cost management also involves leveraging technology. Secure digital workspaces allow experts to review
+            voluminous records remotely, reducing travel time. Virtual meetings keep collaboration efficient while maintaining
+            momentum. By treating experts as partners and respecting their time, we control expenses without compromising the
+            depth of analysis the case deserves.
+          </p>
+
+          <h2>Maintaining Ethical Standards</h2>
+          <p>
+            Ethical considerations govern every interaction with experts. We never ask an expert to alter opinions or ignore
+            unfavorable facts. If an expert identifies weaknesses in our case, we address them honestly and adjust strategy as
+            needed. Transparency preserves credibility with the court and aligns with our duty to present truthful evidence.
+            We also comply with disclosure requirements, providing expert reports and materials within court-ordered deadlines.
+          </p>
+          <p>
+            Experts must understand their ethical obligations as well. We review relevant professional guidelines and ensure
+            testimony stays within their scope of expertise. By maintaining integrity, we build trust with jurors and judges,
+            reinforcing that our pursuit of justice is grounded in honesty.
+          </p>
+
+          <h2>Conclusion</h2>
+          <p>
+            Expert witnesses are indispensable partners in serious injury litigation. Their knowledge illuminates complex
+            issues, supports causation, quantifies damages, and withstands aggressive defense tactics. Selecting the right
+            experts, preparing them thoroughly, and presenting their testimony effectively can make the difference between a
+            modest settlement and a verdict that truly reflects the client’s losses. With strategic use of experts, injured
+            individuals and families gain a powerful voice in the courtroom—one that helps jurors see the full truth and
+            deliver justice.
+          </p>
+        </div>
+      </article>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>&copy; <span id="year"></span> James Kennedy, P.L.L.C. All rights reserved.</p>
+        <div class="footer-links">
+          <a href="../index.html#about">About</a>
+          <a href="../index.html#practice-areas">Practice Areas</a>
+          <a href="index.html">Blog</a>
+          <a href="../contact.html">Contact</a>
+          <a href="../privacy-policy.html">Privacy Policy</a>
+          <a href="../disclaimer.html">Disclaimer</a>
+        </div>
+      </div>
+    </footer>
+
+    <div class="cookie-banner" id="cookie-banner" role="dialog" aria-live="polite">
+      <div class="container cookie-banner__inner">
+        <p>
+          This website uses cookies to analyze site traffic and improve your experience. By
+          clicking “Accept,” you consent to the use of cookies in accordance with our
+          <a href="../privacy-policy.html">Privacy Policy</a>.
+        </p>
+        <button class="btn primary" id="cookie-accept" type="button">Accept</button>
+      </div>
+    </div>
+
+    <script src="../assets/js/main.js"></script>
+  </body>
+</html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Insights &amp; Articles | James B. Kennedy, Jr.</title>
+    <meta
+      name="description"
+      content="Explore legal insights from El Paso personal injury trial lawyer James B. Kennedy, Jr. covering catastrophic injury litigation, trucking crashes, wrongful death, and more."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600&family=Work+Sans:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/css/styles.css" />
+  </head>
+  <body class="interior-page">
+    <header class="site-header">
+      <div class="container">
+        <div class="branding">
+          <div class="logo">JK</div>
+          <div class="identity">
+            <span class="name">James B. Kennedy, Jr.</span>
+            <span class="tagline">Personal Injury Trial Lawyer</span>
+          </div>
+        </div>
+        <a class="cta-pill" href="tel:9155445200">Call 915-544-5200</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="blog-hero">
+        <div class="container narrow">
+          <p class="eyebrow">Legal Insights</p>
+          <h1>Personal Injury Litigation Resources</h1>
+          <p class="lead">
+            Stay informed with long-form articles authored for seriously injured clients and their
+            families. These guides reflect James’ experience handling complex injury litigation
+            throughout the Southwest.
+          </p>
+        </div>
+      </section>
+
+      <section class="blog-listing">
+        <div class="container">
+          <div class="articles-grid">
+            <article class="blog-card">
+              <h3>Building a Strong Personal Injury Case in Texas</h3>
+              <p>
+                Learn how thorough investigation, medical documentation, and litigation strategy work
+                together when pursuing justice after a life-changing injury in Texas courts.
+              </p>
+              <a href="personal-injury-litigation-texas.html">Read article</a>
+            </article>
+            <article class="blog-card">
+              <h3>Dealing with Insurance Companies After a Crash</h3>
+              <p>
+                Understand the tactics insurers use to undervalue claims and how informed negotiation
+                can protect your right to fair compensation following a collision.
+              </p>
+              <a href="insurance-claims-after-accident.html">Read article</a>
+            </article>
+            <article class="blog-card">
+              <h3>Essential Steps After a Serious Trucking Accident</h3>
+              <p>
+                Discover why quick action, evidence preservation, and federal compliance reviews are
+                critical when a commercial vehicle causes catastrophic harm.
+              </p>
+              <a href="building-strong-trucking-case.html">Read article</a>
+            </article>
+            <article class="blog-card">
+              <h3>Calculating Damages in Catastrophic Injury Cases</h3>
+              <p>
+                Explore the categories of economic and non-economic damages available in Texas and how
+                experts help quantify lifelong needs.
+              </p>
+              <a href="catastrophic-injury-damages.html">Read article</a>
+            </article>
+            <article class="blog-card">
+              <h3>What Families Should Know About Wrongful Death Claims</h3>
+              <p>
+                A compassionate overview of eligibility, recoverable damages, and timelines when a
+                loved one’s life is cut short by negligence.
+              </p>
+              <a href="wrongful-death-claims-texas.html">Read article</a>
+            </article>
+            <article class="blog-card">
+              <h3>Understanding Comparative Negligence in Texas</h3>
+              <p>
+                Learn how percentage of fault affects recovery, why statements matter, and how juries
+                evaluate responsibility under Texas law.
+              </p>
+              <a href="comparative-negligence-texas.html">Read article</a>
+            </article>
+            <article class="blog-card">
+              <h3>The Role of Expert Witnesses in Injury Litigation</h3>
+              <p>
+                From accident reconstruction to life-care planning, see how specialized experts build
+                credibility and support complex claims.
+              </p>
+              <a href="expert-witnesses-personal-injury.html">Read article</a>
+            </article>
+            <article class="blog-card">
+              <h3>Preserving Evidence After a Catastrophic Accident</h3>
+              <p>
+                Practical guidance on documenting scenes, safeguarding vehicles, and issuing
+                preservation letters to prevent spoliation.
+              </p>
+              <a href="preserving-evidence-after-crash.html">Read article</a>
+            </article>
+            <article class="blog-card">
+              <h3>Holding Insurers Accountable for Bad Faith</h3>
+              <p>
+                Identify the warning signs of bad faith conduct and the remedies available when an
+                insurer delays or denies valid claims.
+              </p>
+              <a href="insurance-bad-faith-remedies.html">Read article</a>
+            </article>
+            <article class="blog-card">
+              <h3>Preparing for Trial in a Personal Injury Case</h3>
+              <p>
+                A behind-the-scenes look at discovery, motion practice, jury selection, and courtroom
+                storytelling that sets cases up for success.
+              </p>
+              <a href="preparing-for-personal-injury-trial.html">Read article</a>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>&copy; <span id="year"></span> James Kennedy, P.L.L.C. All rights reserved.</p>
+        <div class="footer-links">
+          <a href="../index.html#about">About</a>
+          <a href="../index.html#practice-areas">Practice Areas</a>
+          <a href="index.html" class="active">Blog</a>
+          <a href="../contact.html">Contact</a>
+          <a href="../privacy-policy.html">Privacy Policy</a>
+          <a href="../disclaimer.html">Disclaimer</a>
+        </div>
+      </div>
+    </footer>
+
+    <div class="cookie-banner" id="cookie-banner" role="dialog" aria-live="polite">
+      <div class="container cookie-banner__inner">
+        <p>
+          This website uses cookies to analyze site traffic and improve your experience. By
+          clicking “Accept,” you consent to the use of cookies in accordance with our
+          <a href="../privacy-policy.html">Privacy Policy</a>.
+        </p>
+        <button class="btn primary" id="cookie-accept" type="button">Accept</button>
+      </div>
+    </div>
+
+    <script src="../assets/js/main.js"></script>
+  </body>
+</html>

--- a/blog/insurance-bad-faith-remedies.html
+++ b/blog/insurance-bad-faith-remedies.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Holding Insurers Accountable for Bad Faith | James B. Kennedy, Jr.</title>
+    <meta
+      name="description"
+      content="James B. Kennedy, Jr. explains in 1,500 words how Texans can pursue remedies when insurance companies act in bad faith after catastrophic losses."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600&family=Work+Sans:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/css/styles.css" />
+  </head>
+  <body class="interior-page">
+    <header class="site-header">
+      <div class="container">
+        <div class="branding">
+          <div class="logo">JK</div>
+          <div class="identity">
+            <span class="name">James B. Kennedy, Jr.</span>
+            <span class="tagline">Personal Injury Trial Lawyer</span>
+          </div>
+        </div>
+        <a class="cta-pill" href="tel:9155445200">Call 915-544-5200</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="article-hero">
+        <div class="container narrow">
+          <p class="eyebrow">Insurance Accountability</p>
+          <h1>Holding Insurers Accountable for Bad Faith</h1>
+          <div class="article-meta">
+            <span>By James B. Kennedy, Jr.</span>
+            <span>Fighting for Policyholders</span>
+            <span>Approx. 1,500 words</span>
+          </div>
+        </div>
+      </section>
+
+      <article class="article-content">
+        <div class="container narrow">
+          <p>
+            Insurance exists to provide peace of mind. When tragedy strikes, policyholders expect carriers to honor their
+            promises quickly and fairly. Unfortunately, some insurers delay, underpay, or outright deny valid claims, hoping
+            that frustrated families will accept less than they deserve. Texas law recognizes that this conduct harms not only
+            individual policyholders but also the broader community. For nearly three decades I have confronted carriers that
+            choose profits over people. This article explains what constitutes bad faith, how to document it, and the remedies
+            available when insurers cross the line.
+          </p>
+
+          <h2>Understanding the Duty of Good Faith and Fair Dealing</h2>
+          <p>
+            When Texans purchase insurance, they enter into a contract that includes an implied covenant of good faith and
+            fair dealing. This duty obligates insurers to investigate claims promptly, evaluate them fairly, and pay benefits
+            when liability is reasonably clear. While disputes about coverage can arise, carriers must base their decisions on
+            a reasonable investigation and a good-faith interpretation of policy language. Texas common law and the Insurance
+            Code reinforce these obligations, providing policyholders with avenues to challenge unfair practices.
+          </p>
+          <p>
+            Bad faith can occur in first-party claims, such as uninsured motorist benefits or homeowners insurance, and in
+            third-party contexts where a liability insurer controls settlement decisions on behalf of the insured. In the
+            personal injury arena, we often see bad faith when carriers drag their feet on UM/UIM claims or refuse to settle
+            within policy limits despite clear evidence of catastrophic injuries. Understanding these duties empowers
+            policyholders to recognize red flags early.
+          </p>
+
+          <h2>Common Examples of Bad Faith Conduct</h2>
+          <p>
+            Insurers engage in bad faith when they unreasonably delay or deny benefits without a legitimate basis. Examples
+            include failing to conduct a thorough investigation, ignoring evidence provided by the policyholder, misrepresenting
+            policy terms, or demanding unnecessary documentation repeatedly. Some carriers undervalue damages by cherry-picking
+            medical records or relying on biased software. Others refuse to offer policy limits even when liability is clear,
+            exposing their insureds to excess judgments. In extreme cases, insurers accuse policyholders of fraud without
+            evidence or harass them with invasive surveillance.
+          </p>
+          <p>
+            The Texas Insurance Code also identifies unfair settlement practices, such as failing to acknowledge claims
+            promptly, refusing to pay without reasonable investigation, or compelling policyholders to sue by offering
+            substantially less than what is ultimately recovered. Recognizing these patterns allows us to build a record that
+            supports bad faith allegations.
+          </p>
+
+          <h2>Documenting the Claim Diligently</h2>
+          <p>
+            Thorough documentation is the backbone of a bad faith case. We encourage clients to keep a detailed claim journal
+            noting every phone call, email, and letter from the insurer. Saving copies of correspondence, adjuster reports, and
+            settlement offers creates a timeline of conduct. When an adjuster misstates facts or policy language, we respond in
+            writing to correct the record. Maintaining organized records not only strengthens the underlying injury claim but
+            also demonstrates diligence if litigation becomes necessary.
+          </p>
+          <p>
+            Medical documentation, expert reports, and witness statements should be shared with the insurer promptly. If the
+            carrier ignores or dismisses compelling evidence, that fact supports an argument that they acted unreasonably.
+            Transparency shows that the policyholder fulfilled their obligations, shifting the focus to the insurer’s conduct.
+          </p>
+
+          <h2>Invoking Statutory Remedies</h2>
+          <p>
+            Texas provides statutory remedies for unfair insurance practices. The Texas Insurance Code (Chapters 541 and 542)
+            allows policyholders to seek treble damages, attorney’s fees, and interest when insurers engage in prohibited acts.
+            Chapter 541 addresses unfair or deceptive acts, while Chapter 542—the Prompt Payment of Claims Act—imposes deadlines
+            for acknowledging, investigating, and paying claims. If an insurer violates these timelines without reasonable
+            cause, the policyholder may recover additional damages.
+          </p>
+          <p>
+            To pursue statutory remedies, we send demand letters outlining the violations and giving the insurer an opportunity
+            to cure. These letters must meet specific requirements, including identifying the unfair acts and stating the
+            damages sought. Properly crafted demands set the stage for litigation if the carrier refuses to remedy the conduct.
+          </p>
+
+          <h2>Pursuing Common Law Bad Faith Claims</h2>
+          <p>
+            In addition to statutory remedies, Texas recognizes common law bad faith claims. To prevail, a policyholder must
+            show that the insurer denied or delayed payment when liability was reasonably clear and that the carrier knew or
+            should have known that its denial lacked a reasonable basis. Evidence might include admissions by adjusters, expert
+            testimony, or documents showing that internal guidelines prioritized cost savings over fair evaluation.
+          </p>
+          <p>
+            Common law bad faith claims often accompany breach of contract causes of action. Recoverable damages include the
+            policy benefits owed, consequential damages for financial losses caused by the delay, mental anguish in certain
+            circumstances, and punitive damages when conduct is intentional or malicious. Punitive awards send a strong message
+            that bad faith will not be tolerated.
+          </p>
+
+          <h2>Excess Judgments and Stowers Demands</h2>
+          <p>
+            When a liability insurer refuses to settle within policy limits despite a reasonable opportunity to do so, it may be
+            responsible for the entire judgment, even if it exceeds policy limits. This doctrine originates from the landmark
+            Stowers Furniture Co. v. American Indemnity case. To trigger a Stowers demand, the injured party must offer to settle
+            within policy limits, provide sufficient information to evaluate the claim, and allow a reasonable time to respond.
+            If the insurer rejects the offer and a later verdict exceeds the limits, the insured can pursue the carrier for the
+            excess amount. We use Stowers demands strategically to encourage fair settlements and hold carriers accountable when
+            they gamble with their insured’s financial security.
+          </p>
+          <p>
+            Excess judgment claims often align with catastrophic injury cases where damages clearly exceed policy limits.
+            Demonstrating that the carrier knew the risk yet refused to settle highlights bad faith. These cases can result in
+            substantial recoveries that provide families with the resources they need after life-changing events.
+          </p>
+
+          <h2>Working with the Texas Department of Insurance</h2>
+          <p>
+            Policyholders can file complaints with the Texas Department of Insurance (TDI) if they believe an insurer is
+            violating regulations. While TDI cannot award damages, it can investigate, require responses from carriers, and
+            enforce penalties. Complaints also create a paper trail documenting patterns of misconduct. We often coordinate TDI
+            complaints with litigation strategies, providing regulators with evidence while pursuing civil remedies.
+          </p>
+          <p>
+            TDI responses sometimes reveal additional information about the insurer’s position or internal processes. Sharing
+            these findings with the court bolsters the case for bad faith damages.
+          </p>
+
+          <h2>The Litigation Process</h2>
+          <p>
+            Bad faith litigation unfolds alongside or after the underlying injury case. Discovery allows us to obtain claim
+            manuals, training materials, and adjuster notes. Depositions of adjusters, supervisors, and corporate representatives
+            expose inconsistent explanations or admission of shortcuts. We may retain insurance industry experts to explain
+            proper claims handling standards and how the carrier deviated from them. Mediation provides opportunities to resolve
+            disputes, but we prepare for trial from the outset.
+          </p>
+          <p>
+            At trial, we present a narrative that shows the insurer’s choices in human terms. Jurors learn how delays exacerbated
+            medical debt, how lowball offers compounded stress, and how policyholders felt betrayed by a company they trusted.
+            Demonstrating the contrast between the insurer’s marketing promises and its actual conduct resonates deeply.
+          </p>
+
+          <h2>Coordinating Bad Faith Claims with Injury Litigation</h2>
+          <p>
+            Pursuing bad faith relief while litigating the underlying injury case requires strategic coordination. We evaluate
+            whether to consolidate the actions, sequence them, or bifurcate certain issues to avoid jury confusion. Evidence of
+            the insurer’s misconduct can bolster the injury claim, yet we remain mindful of protecting privileged materials and
+            preventing prejudice. Regular case-management conferences and clear discovery agreements keep both lawsuits moving
+            forward without duplication.
+          </p>
+          <p>
+            Communication with clients is equally important. We explain how the timelines intersect, what documents can be
+            shared, and how settlement offers in one case may affect the other. By approaching both matters as parts of a unified
+            strategy, we maximize leverage and ensure that accountability reaches every party who contributed to the hardship.
+          </p>
+
+          <h2>Protecting Yourself During the Claim</h2>
+          <p>
+            Policyholders can take proactive steps to discourage bad faith. Reading the policy, understanding coverage limits,
+            and reporting claims promptly set the stage for fair handling. Communicating in writing, keeping organized records,
+            and responding to reasonable requests shows good faith. If an adjuster seems evasive or combative, consider seeking
+            legal counsel immediately. Having an attorney manage communications signals to the insurer that the policyholder is
+            serious about enforcing rights.
+          </p>
+          <p>
+            Education is empowering. Knowing that Texas law prohibits unfair practices gives policyholders confidence to stand
+            firm. Remember that silence can be construed as acceptance; if an insurer makes an unreasonable offer, documenting
+            the objections preserves the issue for future litigation.
+          </p>
+
+          <h2>Conclusion</h2>
+          <p>
+            Bad faith insurance practices undermine the very purpose of coverage. When carriers delay, underpay, or deny valid
+            claims, injured Texans suffer twice—first from the accident and then from financial uncertainty. By understanding
+            the duty of good faith, recognizing unfair tactics, and pursuing statutory and common law remedies, policyholders
+            can hold insurers accountable. Aggressive advocacy levels the playing field, encourages fair settlements, and sends
+            a clear message that promises made must be promises kept. Families navigating catastrophic injuries deserve nothing
+            less.
+          </p>
+        </div>
+      </article>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>&copy; <span id="year"></span> James Kennedy, P.L.L.C. All rights reserved.</p>
+        <div class="footer-links">
+          <a href="../index.html#about">About</a>
+          <a href="../index.html#practice-areas">Practice Areas</a>
+          <a href="index.html">Blog</a>
+          <a href="../contact.html">Contact</a>
+          <a href="../privacy-policy.html">Privacy Policy</a>
+          <a href="../disclaimer.html">Disclaimer</a>
+        </div>
+      </div>
+    </footer>
+
+    <div class="cookie-banner" id="cookie-banner" role="dialog" aria-live="polite">
+      <div class="container cookie-banner__inner">
+        <p>
+          This website uses cookies to analyze site traffic and improve your experience. By
+          clicking “Accept,” you consent to the use of cookies in accordance with our
+          <a href="../privacy-policy.html">Privacy Policy</a>.
+        </p>
+        <button class="btn primary" id="cookie-accept" type="button">Accept</button>
+      </div>
+    </div>
+
+    <script src="../assets/js/main.js"></script>
+  </body>
+</html>

--- a/blog/insurance-claims-after-accident.html
+++ b/blog/insurance-claims-after-accident.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dealing with Insurance Companies After a Crash | James B. Kennedy, Jr.</title>
+    <meta
+      name="description"
+      content="Attorney James B. Kennedy, Jr. shares an in-depth, 1,500-word roadmap for protecting your rights when insurance companies handle serious crash claims."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600&family=Work+Sans:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/css/styles.css" />
+  </head>
+  <body class="interior-page">
+    <header class="site-header">
+      <div class="container">
+        <div class="branding">
+          <div class="logo">JK</div>
+          <div class="identity">
+            <span class="name">James B. Kennedy, Jr.</span>
+            <span class="tagline">Personal Injury Trial Lawyer</span>
+          </div>
+        </div>
+        <a class="cta-pill" href="tel:9155445200">Call 915-544-5200</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="article-hero">
+        <div class="container narrow">
+          <p class="eyebrow">Insurance Claim Strategy</p>
+          <h1>Dealing with Insurance Companies After a Crash</h1>
+          <div class="article-meta">
+            <span>By James B. Kennedy, Jr.</span>
+            <span>Representing the Injured Across the Southwest</span>
+            <span>Approx. 1,500 words</span>
+          </div>
+        </div>
+      </section>
+
+      <article class="article-content">
+        <div class="container narrow">
+          <p>
+            Insurance companies often present themselves as trusted partners ready to help policyholders
+            pick up the pieces after a serious crash. In reality, carriers are profit-driven
+            businesses with teams of adjusters, analysts, and defense lawyers trained to limit payouts.
+            Understanding the insurance playbook is the first step toward protecting your rights and
+            securing the compensation Texas law provides. Over nearly three decades of litigating
+            catastrophic injury claims, I have seen countless clients surprised by aggressive tactics,
+            fine-print exclusions, and arbitrary delays. This guide explains what to expect, how to
+            respond, and why experienced legal counsel makes a critical difference when navigating the
+            insurance maze.
+          </p>
+
+          <h2>Report the Crash Promptly but Carefully</h2>
+          <p>
+            Most policies require prompt notice of a collision, and failing to report can jeopardize
+            coverage. However, there is a meaningful difference between providing basic facts and
+            offering detailed statements that insurers can later weaponize. When we notify a carrier,
+            we confirm the date, location, vehicles involved, and the fact that injuries occurred. We
+            refrain from speculating about fault, contributing factors, or the extent of injuries until
+            a full investigation is complete. Recorded statements are particularly risky; adjusters are
+            trained to ask leading questions designed to elicit admissions or minimize symptoms. I
+            advise clients to decline recorded statements until they have legal representation and a
+            clear understanding of the issues at stake.
+          </p>
+          <p>
+            Documenting every contact with the insurer creates a valuable paper trail. Keep copies of
+            letters, emails, claim forms, and adjuster notes. When phone calls occur, record the date,
+            time, participants, and key takeaways. If an adjuster promises to authorize medical
+            treatment or reimburse expenses, follow up in writing. In disputed liability cases, we may
+            send written statements outlining our position to prevent mischaracterizations. Organized
+            documentation becomes powerful evidence if the carrier later alleges the claimant failed to
+            cooperate.
+          </p>
+
+          <h2>Understand the Types of Insurance Involved</h2>
+          <p>
+            Multiple insurance policies may apply after a crash. The at-fault driver’s liability policy
+            is usually the primary source of recovery. In Texas, minimum limits are often inadequate for
+            catastrophic injuries, making it essential to explore additional coverage. Uninsured and
+            underinsured motorist (UM/UIM) policies step in when the negligent driver lacks sufficient
+            insurance. Personal injury protection (PIP) or medical payments coverage can help pay
+            immediate bills regardless of fault. Commercial crashes introduce additional policies, such
+            as motor carrier liability, broker coverage, or umbrella policies. A skilled attorney maps
+            the policy landscape early to avoid missing potential recovery sources.
+          </p>
+          <p>
+            Policy interpretation is a legal task. Endorsements, exclusions, and coordination-of-benefits
+            clauses change the scope of coverage. For example, some UM/UIM policies require written
+            consent before settling with the at-fault driver; failing to obtain permission can forfeit
+            benefits. Others include "offset" provisions that reduce available coverage by the amount of
+            liability payments already received. We examine every clause, analyze case law, and, when
+            necessary, litigate coverage disputes. Insurers rely on policyholders’ unfamiliarity with
+            these nuances, so proactive legal review is indispensable.
+          </p>
+
+          <h2>Beware of Early Settlement Offers</h2>
+          <p>
+            Adjusters sometimes present quick settlement offers, especially when liability is clear and
+            injuries appear serious. These offers are designed to tempt families with immediate cash
+            before the full extent of damages is known. Accepting an early settlement usually requires
+            signing a release that forever waives additional claims, even if complications arise later.
+            I counsel clients to resist pressure and focus on completing medical evaluations. Complex
+            injuries often evolve over months; surgeries may be recommended, permanent impairments may
+            surface, and the true impact on employment may not be immediately obvious. Settling too soon
+            can leave families without the resources they need for long-term care.
+          </p>
+          <p>
+            Instead of rushing to sign a release, we build a demand package that captures current and
+            projected damages. This includes medical summaries, bills, wage loss documentation, and
+            statements from physicians about future care. We also quantify non-economic damages like pain
+            and suffering or loss of consortium, relying on narratives that demonstrate how the crash has
+            altered daily life. When the insurer sees a well-supported demand, it understands that we are
+            prepared to litigate if necessary.
+          </p>
+
+          <h2>Responding to Liability Disputes</h2>
+          <p>
+            Insurers may allege that the injured person contributed to the crash, invoking Texas
+            proportionate responsibility laws to reduce payouts. They might claim that the claimant was
+            speeding, distracted, or failed to take evasive action. We counter these arguments with
+            evidence gathered during our independent investigation: crash data, witness statements,
+            surveillance footage, and expert analysis. Demonstrating that the insured driver violated
+            traffic laws or federal regulations strengthens our liability position and undermines attempts
+            to shift blame.
+          </p>
+          <p>
+            When multiple parties share fault, comparative negligence rules determine how damages are
+            allocated. In Texas, a claimant who is more than 50 percent responsible cannot recover from
+            other parties. We fight aggressively to ensure the defense cannot inflate our client’s
+            percentage of responsibility through speculation. Presenting precise timelines, visual aids,
+            and testimony from reconstructionists helps jurors and adjusters understand the true cause of
+            the collision.
+          </p>
+
+          <h2>Handling Medical Billing and Subrogation</h2>
+          <p>
+            Medical billing is one of the most confusing aspects of post-crash life. Providers may bill
+            health insurance, PIP coverage, or hold accounts on lien while treatment continues. Each
+            payer has subrogation or reimbursement rights that affect the final settlement. Medicare,
+            Medicaid, Veterans Affairs, and ERISA plans impose strict reporting and repayment obligations.
+            Failure to address these interests can jeopardize benefits or result in legal action. My team
+            coordinates with billing offices, negotiates lien reductions, and ensures compliance with all
+            statutory requirements so clients keep as much of their recovery as possible.
+          </p>
+          <p>
+            Insurers sometimes argue that medical charges are unreasonable or unrelated to the crash. We
+            respond by obtaining affidavits of reasonableness, testimony from treating physicians, and
+            peer-reviewed literature supporting the recommended care. In catastrophic injury cases, life-
+            care planners map out future expenses, providing a roadmap that resists insurer attempts to
+            minimize costs. Addressing these issues proactively reduces delays and strengthens our
+            negotiation posture.
+          </p>
+
+          <h2>Navigating Recorded Statements and Independent Medical Exams</h2>
+          <p>
+            Liability carriers frequently request recorded statements and independent medical exams (IMEs)
+            to evaluate claims. As noted earlier, recorded statements can be traps. We prepare clients
+            thoroughly, attend the session when possible, and object to improper questions. If the insurer
+            insists on an IME, we scrutinize the proposed physician’s credentials, bias, and methodology.
+            Some examiners routinely produce reports minimizing injuries; knowing their history helps us
+            cross-examine effectively. We may also request to record the exam or have a representative in
+            attendance to prevent mischaracterization.
+          </p>
+          <p>
+            After the IME, we analyze the report and, if necessary, respond with rebuttal opinions from
+            treating specialists. Courts recognize that IMEs are not truly independent, so credibility is a
+            significant issue. Demonstrating inconsistencies, highlighting selective use of records, and
+            exposing financial relationships between examiners and insurers all help neutralize unfair
+            assessments.
+          </p>
+
+          <h2>Managing Communication and Avoiding Bad Faith</h2>
+          <p>
+            Texas law imposes duties of good faith and fair dealing on insurers when handling first-party
+            claims. Carriers must reasonably investigate, promptly communicate, and attempt fair
+            settlements when liability is clear. When they fail to do so, policyholders may pursue bad
+            faith claims seeking additional damages. Documenting delays, misrepresentations, or unfair
+            valuation practices is essential. We track every request for information, follow up on overdue
+            responses, and demand explanations for low offers. If the carrier refuses to negotiate in good
+            faith, we escalate the matter through statutory demands, complaints to the Texas Department of
+            Insurance, or litigation.
+          </p>
+          <p>
+            Communication discipline also protects clients from inadvertent missteps. Posting about the
+            crash on social media, discussing the claim with strangers, or exaggerating symptoms can
+            undermine credibility. We coach clients on maintaining privacy and responding honestly to all
+            inquiries. Credibility is the cornerstone of every case; by presenting consistent, truthful
+            information, we erode the insurer’s ability to question the claim.
+          </p>
+
+          <h2>Preparing for Litigation</h2>
+          <p>
+            When negotiations stall, filing a lawsuit demonstrates commitment to pursuing justice. Litigation
+            triggers formal discovery tools, including interrogatories, document requests, and depositions.
+            Insurers who previously dragged their feet must respond under oath. We use discovery to uncover
+            safety violations, corporate policies, and prior incidents that reveal patterns of negligence.
+            Litigation also puts a judge in position to resolve disputes about discovery, coverage, or legal
+            defenses. While lawsuits lengthen the timeline, they often lead to more realistic settlement
+            offers as trial approaches.
+          </p>
+          <p>
+            Throughout litigation, we continue to evaluate new evidence, update damages calculations, and
+            prepare for mediation or trial. Focus groups help test themes and identify questions jurors may
+            have. Demonstrative exhibits, such as 3D crash animations or day-in-the-life videos, illustrate
+            the human toll of the collision. By demonstrating readiness for trial, we encourage insurers to
+            reevaluate the risk of facing a jury.
+          </p>
+
+          <h2>Understanding Timeframes and Patience</h2>
+          <p>
+            Insurance claims move slowly, particularly when catastrophic injuries are involved. Medical
+            treatment must progress, experts need time to prepare analyses, and courts manage crowded
+            dockets. Setting realistic expectations helps clients remain patient. We provide timelines for
+            each phase—investigation, demand preparation, negotiation, litigation—and update clients as
+            circumstances evolve. Transparency reduces anxiety and allows families to focus on recovery.
+          </p>
+          <p>
+            Patience does not mean passivity. We continually push the claim forward, enforce deadlines, and
+            hold insurers accountable. Regular check-ins with clients ensure we capture new medical
+            developments or employment impacts promptly. Momentum is critical; even though the process is
+            lengthy, disciplined follow-through prevents stagnation.
+          </p>
+
+          <h2>The Value of Experienced Legal Representation</h2>
+          <p>
+            Facing an insurance company alone can feel overwhelming. Adjusters speak a specialized language,
+            know the loopholes, and often present themselves as friendly advisors while quietly building a
+            case against the claimant. Having an experienced trial lawyer levels the playing field. We
+            coordinate investigations, manage medical evidence, negotiate aggressively, and prepare for trial
+            from day one. Insurers recognize which lawyers are willing to take cases to verdict and adjust
+            their strategies accordingly. By demonstrating strength, we increase the likelihood of a fair
+            settlement without compromising our readiness for court.
+          </p>
+          <p>
+            Ultimately, dealing with insurance companies after a crash is about reclaiming control. By
+            understanding policy terms, documenting every interaction, resisting lowball offers, and seeking
+            trusted counsel, injured people and their families can navigate the process with confidence. The
+            path may be complex, but with strategic guidance, persistence, and a clear focus on the client’s
+            needs, insurance negotiations can lead to outcomes that support healing and accountability.
+          </p>
+        </div>
+      </article>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>&copy; <span id="year"></span> James Kennedy, P.L.L.C. All rights reserved.</p>
+        <div class="footer-links">
+          <a href="../index.html#about">About</a>
+          <a href="../index.html#practice-areas">Practice Areas</a>
+          <a href="index.html">Blog</a>
+          <a href="../contact.html">Contact</a>
+          <a href="../privacy-policy.html">Privacy Policy</a>
+          <a href="../disclaimer.html">Disclaimer</a>
+        </div>
+      </div>
+    </footer>
+
+    <div class="cookie-banner" id="cookie-banner" role="dialog" aria-live="polite">
+      <div class="container cookie-banner__inner">
+        <p>
+          This website uses cookies to analyze site traffic and improve your experience. By
+          clicking “Accept,” you consent to the use of cookies in accordance with our
+          <a href="../privacy-policy.html">Privacy Policy</a>.
+        </p>
+        <button class="btn primary" id="cookie-accept" type="button">Accept</button>
+      </div>
+    </div>
+
+    <script src="../assets/js/main.js"></script>
+  </body>
+</html>

--- a/blog/personal-injury-litigation-texas.html
+++ b/blog/personal-injury-litigation-texas.html
@@ -1,0 +1,295 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Building a Strong Personal Injury Case in Texas | James B. Kennedy, Jr.</title>
+    <meta
+      name="description"
+      content="A comprehensive, 1,500-word guide from attorney James B. Kennedy, Jr. on building a compelling personal injury case in Texas from investigation through trial."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600&family=Work+Sans:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/css/styles.css" />
+  </head>
+  <body class="interior-page">
+    <header class="site-header">
+      <div class="container">
+        <div class="branding">
+          <div class="logo">JK</div>
+          <div class="identity">
+            <span class="name">James B. Kennedy, Jr.</span>
+            <span class="tagline">Personal Injury Trial Lawyer</span>
+          </div>
+        </div>
+        <a class="cta-pill" href="tel:9155445200">Call 915-544-5200</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="article-hero">
+        <div class="container narrow">
+          <p class="eyebrow">Texas Personal Injury Litigation</p>
+          <h1>Building a Strong Personal Injury Case in Texas</h1>
+          <div class="article-meta">
+            <span>By James B. Kennedy, Jr.</span>
+            <span>Trial Lawyer Serving Texas, New Mexico, Colorado, Arizona &amp; Nevada</span>
+            <span>Approx. 1,500 words</span>
+          </div>
+        </div>
+      </section>
+
+      <article class="article-content">
+        <div class="container narrow">
+          <p>
+            Building a compelling personal injury case in Texas requires far more than filing a claim
+            and waiting for a settlement offer. Success is rooted in a disciplined approach that
+            respects the state’s legal standards, anticipates the tactics of powerful defendants, and
+            keeps the injured client at the center of every strategic decision. From the moment a
+            catastrophic crash, workplace incident, or defective product changes a family’s life,
+            every action should reinforce the story of accountability and the client’s path toward
+            healing. The following guide draws on decades of trial experience in El Paso and courts
+            across the Southwest to map out the steps that help plaintiffs obtain the full measure of
+            justice Texas law allows.
+          </p>
+
+          <h2>Prioritizing Immediate Medical Care and Documentation</h2>
+          <p>
+            The foundation of any personal injury case is the client’s health. Encouraging prompt
+            medical care is not only the right thing to do for a person in pain—it also establishes a
+            contemporaneous record that links the injury to the harmful event. Emergency room
+            evaluations, diagnostic imaging, and specialist referrals demonstrate the severity of the
+            trauma and guard against defense arguments that the injuries were minor or preexisting. I
+            remind clients that even if they feel shaken but not severely hurt, adrenaline can mask
+            symptoms of internal bleeding, traumatic brain injury, or spinal damage that could worsen
+            without immediate attention. Every treatment entry, prescription, and physician note later
+            helps tell the story of the harm inflicted.
+          </p>
+          <p>
+            Once the client is stable, documenting the progression of treatment is crucial. Keeping a
+            journal of daily pain levels, mobility restrictions, and emotional challenges creates a
+            human record that complements medical charts. Encouraging clients to save receipts for
+            medications, travel to appointments, medical devices, and home modifications ensures we
+            can fully capture economic damages. When litigation begins, the defense will scrutinize
+            any gaps in care or inconsistent follow-through, so I work closely with treating
+            physicians and case managers to maintain continuity. Coordinating multidisciplinary care
+            teams, from neurologists to vocational experts, strengthens the narrative that every
+            resource is being marshaled to restore the client’s quality of life.
+          </p>
+
+          <h2>Conducting Thorough Liability Investigations</h2>
+          <p>
+            While medical care moves forward, the investigative team must secure evidence before it
+            disappears. In motor vehicle and trucking cases, that means photographing the scene,
+            capturing measurements, and documenting road conditions, weather patterns, and traffic
+            control devices. I often retain accident reconstructionists early to download vehicle data
+            recorders, inspect impact points, and determine whether the crash dynamics align with the
+            defendant’s version of events. In premises liability or industrial incidents, preserving
+            maintenance logs, safety manuals, and surveillance footage can expose systemic failures.
+            Texas law allows spoliation instructions when defendants destroy evidence, but it is far
+            better to secure critical proof before it goes missing.
+          </p>
+          <p>
+            Witness interviews should be approached with the same rigor. Memories fade quickly, and
+            unrepresented witnesses may be contacted by insurers eager to shape the narrative. My
+            team reaches out respectfully, obtains sworn statements when appropriate, and documents
+            every interaction. In complex cases, we consider employing private investigators to locate
+            hard-to-find witnesses or uncover corporate relationships. A thorough investigation also
+            means looking inward: examining our client’s social media presence, employment history,
+            and prior claims allows us to anticipate defense attacks and address potential weaknesses
+            honestly. Transparency builds credibility with juries and judges who expect plaintiffs to
+            confront difficult facts head-on.
+          </p>
+
+          <h2>Preserving Critical Evidence Through Litigation Holds</h2>
+          <p>
+            Sending a timely preservation letter is one of the most important steps after accepting a
+            case. These litigation holds place defendants and third parties on notice that evidence
+            must be retained. In trucking cases, that includes driver qualification files, hours-of-
+            service logs, dispatch records, maintenance histories, and satellite tracking data. For
+            product liability matters, we demand schematics, testing results, and communications about
+            known defects. Texas courts take spoliation seriously, but judges will also consider
+            whether the plaintiff acted diligently in requesting materials. A well-crafted letter
+            citing relevant regulations and specifying categories of evidence signals that we are ready
+            to litigate aggressively if compliance falters.
+          </p>
+          <p>
+            When necessary, we file motions for temporary restraining orders to secure vehicles,
+            machinery, or dangerous products that might otherwise be altered. Arranging joint
+            inspections allows both sides to document the condition of the evidence while maintaining
+            a chain of custody. If opposing parties resist, we seek court intervention early rather
+            than allowing the dispute to linger. Every preserved document, photograph, and physical
+            sample becomes a puzzle piece that can be assembled into a compelling liability story.
+          </p>
+
+          <h2>Understanding Texas Statutes, Venue, and Procedural Nuances</h2>
+          <p>
+            Texas civil practice rules and statutory deadlines require constant vigilance. The general
+            two-year statute of limitations for personal injury claims may be shortened or extended by
+            specific circumstances, such as government-entity involvement or exposure to harmful
+            substances. Early analysis of potential defendants ensures we do not overlook a liable
+            party whose inclusion could expand insurance coverage or open punitive damage avenues. I
+            also evaluate venue options, balancing the practicalities of where witnesses live with the
+            tendencies of local juries. Filing in the appropriate county can influence discovery
+            timelines, docket speeds, and ultimately the complexion of a trial.
+          </p>
+          <p>
+            Procedural nuances matter at every stage. Understanding proportionate responsibility and
+            joint-and-several liability helps shape how we plead causes of action. Mastery of Chapter
+            74 requirements in health care liability claims, the dram shop statute for alcohol-related
+            crashes, or the intricacies of the Texas Tort Claims Act equips us to navigate dismissal
+            attempts. Attention to detail with affidavits, discovery responses, and expert disclosures
+            keeps our case on track and positions us to defeat summary judgment motions. The defense
+            is always searching for technical missteps; disciplined file management denies them that
+            opportunity.
+          </p>
+
+          <h2>Calculating Full and Fair Damages</h2>
+          <p>
+            A strong case quantifies every harm the client endures. Economic damages include medical
+            bills, lost wages, diminished earning capacity, vocational retraining, and the cost of
+            long-term care. We collaborate with life-care planners and economists to model future
+            needs, adjusting for inflation, wage growth, and realistic work-life expectations. In
+            catastrophic injury cases, we evaluate home renovations, attendant care, adaptive
+            technology, and transportation modifications that allow clients to live with dignity. For
+            families pursuing wrongful death claims, we calculate the loss of support, household
+            services, and inheritance expectations to reflect the tangible void left behind.
+          </p>
+          <p>
+            Non-economic damages require careful storytelling rooted in the client’s lived
+            experience. Pain and suffering, mental anguish, physical impairment, disfigurement, and
+            loss of consortium cannot be measured with a spreadsheet, but they are no less real.
+            Capturing testimony from loved ones, coworkers, coaches, and community members reveals how
+            the injury reverberates through every facet of daily life. Jurors respond to specific
+            examples: the father who can no longer pick up his child, the nurse who lost the ability
+            to stand during a shift, the athlete whose identity was tied to movement. Vivid, honest
+            narratives transform abstract legal categories into meaningful compensation.
+          </p>
+
+          <h2>Collaborating with Expert Witnesses</h2>
+          <p>
+            Expert witnesses translate complex concepts into language jurors understand. Accident
+            reconstructionists explain impact forces, biomedical engineers evaluate product defects,
+            and human-factors specialists analyze decision-making under stress. Medical experts
+            articulate causation, future treatment needs, and prognoses with authority. Economists and
+            vocational rehabilitation specialists connect injuries to lost earning capacity. Selecting
+            the right experts means balancing credentials, communication skills, and courtroom
+            presence. I prepare experts thoroughly, ensuring they review all relevant materials and
+            can defend their opinions under cross-examination.
+          </p>
+          <p>
+            Collaboration goes both ways. Experts often identify additional evidence worth pursuing or
+            suggest demonstrative exhibits that make complicated science visual. I involve them early
+            enough to influence discovery requests and deposition strategies. When opposing experts
+            offer questionable conclusions, we analyze their methodologies meticulously and consider
+            Daubert challenges to exclude unreliable testimony. Expert battles can shape the outcome
+            of catastrophic injury trials, so investing time and resources into these relationships is
+            essential.
+          </p>
+
+          <h2>Engaging with Insurance Companies Strategically</h2>
+          <p>
+            Insurance carriers are sophisticated adversaries whose business models depend on minimizing
+            payouts. They will question liability, dispute medical necessity, and search for prior
+            injuries. I approach negotiations with a comprehensive demand package that includes a
+            detailed narrative, medical summaries, expert reports, demonstrative graphics, and a
+            settlement range supported by comparable verdicts. Presenting a fully developed case early
+            can prompt meaningful discussions, but I never assume the adjuster will negotiate fairly
+            without pressure. Mediation can be productive when scheduled after key depositions or
+            expert disclosures, yet I prepare every client for the possibility that trial is the only
+            path to justice.
+          </p>
+          <p>
+            Throughout negotiations, clear communication with the client is vital. Explaining the
+            insurer’s offers, the costs of continued litigation, and the risks of trial empowers the
+            client to make informed decisions. Transparency builds trust, and clients appreciate when
+            their lawyer respects their role as the ultimate decision-maker. Documenting every demand
+            and response also lays the groundwork for potential bad faith claims if the carrier acts
+            unreasonably.
+          </p>
+
+          <h2>Preparing Relentlessly for Trial</h2>
+          <p>
+            Even when settlement appears likely, I prepare each file as though we will select a jury
+            tomorrow. That discipline sharpens discovery, keeps witnesses engaged, and signals to the
+            defense that we are ready to try the case. Trial preparation includes crafting opening
+            statements that frame the story, organizing exhibits for seamless presentation, and
+            creating timelines that align testimony with documents. Focus groups and mock trials
+            reveal how community members react to themes, defenses, and witness credibility, allowing
+            adjustments before stepping into the courtroom.
+          </p>
+          <p>
+            Jury selection deserves special attention in Texas, where community values can vary
+            dramatically from county to county. Understanding local attitudes about corporate
+            responsibility, damages, and government regulation guides voir dire questions. During
+            trial, we weave together expert testimony, lay witnesses, and demonstrative evidence to
+            create a persuasive narrative that underscores accountability. Closing arguments tie every
+            strand together, reminding jurors that their verdict not only compensates the client but
+            also reinforces community safety standards.
+          </p>
+
+          <h2>Supporting Clients Beyond the Courtroom</h2>
+          <p>
+            A strong case also acknowledges the human side of litigation. Injured clients often face
+            financial strain, emotional distress, and uncertainty about the future. Connecting them
+            with medical providers who will treat on liens, guiding them through disability
+            applications, and referring them to support groups demonstrates compassionate advocacy. I
+            maintain regular contact, providing updates and explaining legal developments in plain
+            language so clients never feel left in the dark. That trust encourages candor and helps us
+            respond quickly to new information.
+          </p>
+          <p>
+            After a verdict or settlement, we continue assisting with lien resolution, structured
+            settlement evaluations, and financial planning referrals. Ensuring that compensation lasts
+            and that medical providers are paid honors the promise we make at the beginning of the
+            representation. Clients who feel supported throughout the process often become powerful
+            advocates, referring friends and family who need help after their own tragedies.
+          </p>
+
+          <h2>Conclusion</h2>
+          <p>
+            Building a strong personal injury case in Texas is a meticulous, client-centered process
+            that demands legal knowledge, strategic foresight, and relentless advocacy. By prioritizing
+            medical care, conducting exhaustive investigations, preserving evidence, quantifying
+            damages, collaborating with experts, and preparing for trial from day one, plaintiffs can
+            stand toe-to-toe with well-funded defendants. For injured individuals and families, the
+            journey is daunting, but with the right team and a disciplined plan, justice is within
+            reach. Every case is an opportunity to restore dignity, secure necessary resources, and
+            make the community safer for everyone.
+          </p>
+        </div>
+      </article>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>&copy; <span id="year"></span> James Kennedy, P.L.L.C. All rights reserved.</p>
+        <div class="footer-links">
+          <a href="../index.html#about">About</a>
+          <a href="../index.html#practice-areas">Practice Areas</a>
+          <a href="index.html">Blog</a>
+          <a href="../contact.html">Contact</a>
+          <a href="../privacy-policy.html">Privacy Policy</a>
+          <a href="../disclaimer.html">Disclaimer</a>
+        </div>
+      </div>
+    </footer>
+
+    <div class="cookie-banner" id="cookie-banner" role="dialog" aria-live="polite">
+      <div class="container cookie-banner__inner">
+        <p>
+          This website uses cookies to analyze site traffic and improve your experience. By
+          clicking “Accept,” you consent to the use of cookies in accordance with our
+          <a href="../privacy-policy.html">Privacy Policy</a>.
+        </p>
+        <button class="btn primary" id="cookie-accept" type="button">Accept</button>
+      </div>
+    </div>
+
+    <script src="../assets/js/main.js"></script>
+  </body>
+</html>

--- a/blog/preparing-for-personal-injury-trial.html
+++ b/blog/preparing-for-personal-injury-trial.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Preparing for Trial in a Personal Injury Case | James B. Kennedy, Jr.</title>
+    <meta
+      name="description"
+      content="A 1,500-word roadmap from trial lawyer James B. Kennedy, Jr. on preparing catastrophic injury cases for courtroom success."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600&family=Work+Sans:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/css/styles.css" />
+  </head>
+  <body class="interior-page">
+    <header class="site-header">
+      <div class="container">
+        <div class="branding">
+          <div class="logo">JK</div>
+          <div class="identity">
+            <span class="name">James B. Kennedy, Jr.</span>
+            <span class="tagline">Personal Injury Trial Lawyer</span>
+          </div>
+        </div>
+        <a class="cta-pill" href="tel:9155445200">Call 915-544-5200</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="article-hero">
+        <div class="container narrow">
+          <p class="eyebrow">Trial Preparation</p>
+          <h1>Preparing for Trial in a Personal Injury Case</h1>
+          <div class="article-meta">
+            <span>By James B. Kennedy, Jr.</span>
+            <span>Board-Certified Trial Lawyer</span>
+            <span>Approx. 1,500 words</span>
+          </div>
+        </div>
+      </section>
+
+      <article class="article-content">
+        <div class="container narrow">
+          <p>
+            Trial preparation is where diligence meets storytelling. While many personal injury cases settle, the best results
+            come when a lawyer prepares every file as if a jury will render the final decision. That mindset strengthens
+            negotiations, reveals the truth, and honors the client’s journey. Over decades in the courtroom, I have developed a
+            disciplined process that guides catastrophic injury cases from intake to verdict. This article outlines the key
+            components of trial preparation and the practical steps that build persuasive presentations.
+          </p>
+
+          <h2>Start with a Comprehensive Case Theory</h2>
+          <p>
+            Trial preparation begins on day one. We develop a working theory that answers three questions: What happened? Why
+            was it wrong? How did it change the client’s life? This theory shapes discovery, expert selection, and witness
+            preparation. As new evidence emerges, we refine the theory to ensure it remains accurate and compelling. A strong
+            case theory highlights the defendant’s choices, aligns with juror values, and weaves liability and damages into a
+            cohesive narrative.
+          </p>
+          <p>
+            To build this theory, we conduct thorough client interviews, review medical records, and analyze available
+            documents. We visit the scene, talk to witnesses, and gather photographs or videos. Creating timelines helps visualize
+            events and identify gaps. By the time the complaint is filed, we already know the major themes that will carry the
+            case through trial.
+          </p>
+
+          <h2>Master the Evidence</h2>
+          <p>
+            Effective trial lawyers know the evidence better than anyone else in the courtroom. We organize documents using
+            detailed indices, chronologies, and issue-specific binders. Depositions are transcribed and summarized, with key
+            passages highlighted for quick reference. Digital evidence, such as photographs, videos, and telematics data, is
+            cataloged and stored securely. When new discovery arrives, we integrate it immediately, noting how it supports or
+            challenges our theory.
+          </p>
+          <p>
+            Mastery of evidence also means anticipating objections. We analyze hearsay issues, authenticate digital files, and
+            prepare motions in limine to exclude prejudicial materials. Building demonstrative exhibits, such as medical
+            illustrations or accident reconstructions, requires coordinating with experts and ensuring compliance with evidentiary
+            rules. The goal is to present information clearly and confidently so jurors focus on substance rather than procedure.
+          </p>
+
+          <h2>Prepare Witnesses with Care</h2>
+          <p>
+            Witness testimony breathes life into the case. We meet with each witness to review their recollections, clarify
+            timelines, and practice answering questions succinctly. Lay witnesses—family members, coworkers, friends—provide
+            powerful insights into the client’s life before and after the injury. We encourage them to use vivid examples rather
+            than generalities. For example, describing how a client once coached Little League but can no longer throw a ball is
+            more compelling than simply saying they are less active.
+          </p>
+          <p>
+            Expert witnesses require specialized preparation. We review their reports, explore potential cross-examination topics,
+            and conduct mock direct examinations. Experts must explain complex concepts in plain language. They should understand
+            courtroom decorum, the importance of answering only the question asked, and how to handle hypothetical scenarios.
+            Building rapport with experts fosters teamwork and ensures consistent messaging.
+          </p>
+
+          <h2>Anticipate the Defense</h2>
+          <p>
+            Preparing for trial involves studying the defense just as carefully as our own case. We analyze discovery responses,
+            deposition testimony, and expert reports to identify themes the defense will advance. Common strategies include
+            challenging causation, minimizing damages, or blaming third parties. We craft cross-examination outlines that expose
+            inconsistencies, highlight admissions, and reinforce our core theory.
+          </p>
+          <p>
+            Motions play a crucial role in shaping the evidentiary landscape. We file motions to compel discovery, exclude
+            unreliable experts, or prevent irrelevant character attacks. We also prepare responses to anticipated defense motions,
+            ensuring the judge hears our perspective before ruling. Addressing these issues early keeps the trial focused on the
+            facts that matter most.
+          </p>
+
+          <h2>Develop Persuasive Demonstratives</h2>
+          <p>
+            Visual storytelling enhances juror understanding. We collaborate with graphic designers, animators, and medical
+            illustrators to create demonstrative exhibits tailored to the case. Timelines, anatomical diagrams, and day-in-the-life
+            videos reinforce key themes. 3D models or interactive presentations can reconstruct crash dynamics or explain complex
+            surgeries. Demonstratives should be accurate, easy to follow, and admissible under evidentiary rules. We share drafts
+            with experts and adjust based on their feedback to maintain scientific integrity.
+          </p>
+          <p>
+            Demonstratives also aid in mediation. Showing the defense a preview of what jurors will see encourages realistic
+            settlement discussions. Even when cases resolve short of trial, these visual tools demonstrate our readiness and the
+            strength of our presentation.
+          </p>
+
+          <h2>Conduct Focus Groups and Mock Trials</h2>
+          <p>
+            Jurors bring diverse life experiences into the courtroom. Focus groups and mock trials provide invaluable insight into
+            how community members perceive our themes, witnesses, and exhibits. We present condensed versions of the case and
+            listen carefully to feedback. Do jurors understand the mechanics of the accident? Which witnesses resonate most? Are
+            there concerns we need to address in voir dire or closing arguments? Incorporating this feedback refines our approach
+            and prepares us for unexpected questions.
+          </p>
+          <p>
+            These exercises also reveal potential biases or misconceptions. For example, focus groups might assume a client who
+            returned to part-time work has fully recovered. Knowing this, we emphasize medical testimony explaining the limits of
+            that work. Data from mock trials informs jury selection strategies and shapes how we explain damages.
+          </p>
+
+          <h2>Plan Voir Dire Thoughtfully</h2>
+          <p>
+            Voir dire sets the tone for trial. We craft questions that uncover biases related to personal injury lawsuits,
+            corporate accountability, or damage awards. Understanding jurors’ attitudes toward safety rules, insurance companies,
+            and government regulation helps us identify who will evaluate the case fairly. We aim to build rapport, encourage
+            honest dialogue, and educate jurors about the issues they will decide.
+          </p>
+          <p>
+            We also prepare for the judge’s preferences, reviewing local rules and standing orders. Having proposed jury
+            questionnaires, strike lists, and seating charts ready streamlines the process. Voir dire is not about persuading
+            jurors; it is about selecting those who can be open-minded and apply the law impartially.
+          </p>
+
+          <h2>Craft Opening Statements and Closings</h2>
+          <p>
+            Opening statements introduce the narrative. We outline the evidence, explain the defendant’s negligence, and preview
+            the damages. The tone is confident yet respectful. We avoid exaggeration and focus on clarity. Opening statements are
+            rehearsed extensively, often with colleagues providing feedback on pacing, visuals, and transitions.
+          </p>
+          <p>
+            Closing arguments tie everything together. We revisit the case theory, walk through the jury charge, and show how the
+            evidence meets each element. We quantify damages, using exhibits and testimony to support every number. Closings are
+            also an opportunity to speak about community safety and the role of the civil justice system in preventing future
+            harm. Authenticity and compassion resonate with jurors as they prepare to deliberate.
+          </p>
+
+          <h2>Prepare the Client Emotionally</h2>
+          <p>
+            Trial is stressful. Clients relive traumatic events and face intense scrutiny. We dedicate time to preparing them for
+            the emotional demands of testimony, media attention, and courtroom protocols. Explaining the schedule, breaks, and
+            roles of courtroom personnel reduces anxiety. Encouraging clients to practice mindfulness, counseling, or other
+            support services helps them stay grounded.
+          </p>
+          <p>
+            We also discuss realistic outcomes. Juries are unpredictable, and even well-tried cases can produce surprising
+            verdicts. Setting expectations fosters trust. Regardless of the outcome, clients appreciate knowing that their story
+            was told with dignity and that every effort was made to pursue justice.
+          </p>
+
+          <h2>Logistics and Trial Technology</h2>
+          <p>
+            Smooth logistics allow the legal team to focus on advocacy. We reserve war rooms near the courthouse, organize trial
+            binders, and test audio-visual equipment. Exhibits are preloaded onto presentation software, with backups available
+            in case of technical issues. Witness schedules are coordinated to minimize downtime. We also plan for contingencies,
+            such as replacing a sick witness or adjusting for unexpected rulings.
+          </p>
+          <p>
+            Technology enhances juror engagement when used thoughtfully. Digital presentations, synced exhibits, and real-time
+            transcripts keep the proceedings efficient. However, we ensure technology never overshadows the human story at the
+            heart of the case. Jurors connect most deeply with authentic testimony and clear explanations.
+          </p>
+
+          <h2>Post-Trial Responsibilities</h2>
+          <p>
+            Preparation does not end when the verdict is read. We debrief with the client, witnesses, and team members to review
+            what worked well and what can improve in future trials. If post-trial motions or appeals arise, the trial record we
+            built becomes the foundation for defending the judgment. We secure exhibits, transcripts, and demonstratives, storing
+            them for potential appellate review while maintaining client confidentiality.
+          </p>
+          <p>
+            We also assist clients with practical next steps: navigating lien resolution, structuring settlements, or preparing
+            for remittitur hearings. When punitive damages or interest calculations require additional briefing, we move swiftly
+            to protect the result. Staying engaged after the verdict ensures the client fully benefits from the work invested in
+            trial preparation.
+          </p>
+
+          <h2>Conclusion</h2>
+          <p>
+            Preparing for trial in a personal injury case requires unwavering attention to detail, strategic foresight, and
+            heartfelt advocacy. By developing a compelling case theory, mastering evidence, preparing witnesses, anticipating the
+            defense, leveraging demonstratives, and supporting the client, we create a courtroom presentation that honors the
+            truth. Whether a case settles on the courthouse steps or proceeds to verdict, disciplined trial preparation ensures
+            that injured individuals have a powerful voice. The courtroom is where accountability happens, and with meticulous
+            preparation, justice can prevail.
+          </p>
+        </div>
+      </article>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>&copy; <span id="year"></span> James Kennedy, P.L.L.C. All rights reserved.</p>
+        <div class="footer-links">
+          <a href="../index.html#about">About</a>
+          <a href="../index.html#practice-areas">Practice Areas</a>
+          <a href="index.html">Blog</a>
+          <a href="../contact.html">Contact</a>
+          <a href="../privacy-policy.html">Privacy Policy</a>
+          <a href="../disclaimer.html">Disclaimer</a>
+        </div>
+      </div>
+    </footer>
+
+    <div class="cookie-banner" id="cookie-banner" role="dialog" aria-live="polite">
+      <div class="container cookie-banner__inner">
+        <p>
+          This website uses cookies to analyze site traffic and improve your experience. By
+          clicking “Accept,” you consent to the use of cookies in accordance with our
+          <a href="../privacy-policy.html">Privacy Policy</a>.
+        </p>
+        <button class="btn primary" id="cookie-accept" type="button">Accept</button>
+      </div>
+    </div>
+
+    <script src="../assets/js/main.js"></script>
+  </body>
+</html>

--- a/blog/preserving-evidence-after-crash.html
+++ b/blog/preserving-evidence-after-crash.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Preserving Evidence After a Catastrophic Accident | James B. Kennedy, Jr.</title>
+    <meta
+      name="description"
+      content="A 1,500-word guide from attorney James B. Kennedy, Jr. on protecting crucial evidence after serious crashes, industrial disasters, or product failures."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600&family=Work+Sans:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/css/styles.css" />
+  </head>
+  <body class="interior-page">
+    <header class="site-header">
+      <div class="container">
+        <div class="branding">
+          <div class="logo">JK</div>
+          <div class="identity">
+            <span class="name">James B. Kennedy, Jr.</span>
+            <span class="tagline">Personal Injury Trial Lawyer</span>
+          </div>
+        </div>
+        <a class="cta-pill" href="tel:9155445200">Call 915-544-5200</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="article-hero">
+        <div class="container narrow">
+          <p class="eyebrow">Evidence Preservation</p>
+          <h1>Preserving Evidence After a Catastrophic Accident</h1>
+          <div class="article-meta">
+            <span>By James B. Kennedy, Jr.</span>
+            <span>Relentless Advocate for the Injured</span>
+            <span>Approx. 1,500 words</span>
+          </div>
+        </div>
+      </section>
+
+      <article class="article-content">
+        <div class="container narrow">
+          <p>
+            Evidence is the lifeblood of a personal injury case. Without it, even the most righteous claims struggle to gain
+            traction. After a catastrophic accident, evidence can disappear quickly: vehicles are towed away and repaired,
+            industrial sites resume operations, and digital data is overwritten. Defendants and insurers may start their own
+            investigations immediately, focusing on information that supports their narrative. Injured people and their
+            families must act with equal urgency to protect proof that tells the full story. Drawing from years of trial
+            experience, this guide explains the practical steps we take to preserve evidence after devastating events.
+          </p>
+
+          <h2>Seek Medical Care First</h2>
+          <p>
+            Health and safety come before litigation. The first priority after any serious incident is securing emergency
+            medical care. Prompt treatment saves lives and creates contemporaneous records linking injuries to the event. Once
+            the injured person is stabilized, we begin implementing an evidence preservation plan. Medical documentation
+            itself is a form of evidence; keeping track of diagnoses, imaging results, and treatment plans will later support
+            causation and damages claims.
+          </p>
+
+          <h2>Engage Legal Counsel Quickly</h2>
+          <p>
+            Time-sensitive evidence requires immediate attention. Retaining a lawyer early allows us to send preservation
+            letters, coordinate investigations, and interact with insurers on the client’s behalf. Our firm maintains
+            relationships with accident reconstructionists, engineers, human-factors experts, and investigators who can mobilize
+            quickly. We visit crash scenes, job sites, or homes to document conditions before they change. Acting fast can be
+            the difference between obtaining critical proof and learning it has been discarded.
+          </p>
+
+          <h2>Issue Preservation Letters and Litigation Holds</h2>
+          <p>
+            A preservation letter notifies potential defendants and third parties that litigation is anticipated and that they
+            must retain relevant evidence. These letters describe the incident, identify the categories of evidence to be
+            preserved, and cite legal obligations. In trucking cases, we demand driver logs, electronic control module data,
+            dispatch communications, maintenance records, and vehicle components. In industrial incidents, we request safety
+            manuals, inspection reports, surveillance footage, and employee training records. Sending a comprehensive letter
+            early establishes our diligence and lays the foundation for sanctions if evidence later disappears.
+          </p>
+          <p>
+            We also advise clients to preserve their own materials. This includes saving damaged personal items, retaining
+            clothing worn during the incident, and backing up cell phone data. Photographing injuries, property damage, and
+            recovery milestones creates a visual timeline that can be persuasive to jurors.
+          </p>
+
+          <h2>Secure Physical Evidence</h2>
+          <p>
+            Physical evidence may include vehicles, machinery, tools, safety equipment, or defective products. When possible,
+            we arrange for secure storage where items can be inspected by experts. In vehicle collisions, we request that
+            towing companies hold vehicles until a joint inspection occurs. For product liability cases, we work with experts to
+            photograph, measure, and analyze the item without altering it. Maintaining a chain of custody ensures the defense
+            cannot argue that evidence was tampered with.
+          </p>
+          <p>
+            If a defendant refuses to preserve physical evidence, we seek court intervention through temporary restraining
+            orders or expedited discovery. Judges understand that once physical evidence is altered or destroyed, the truth may
+            never be known. Courts can impose sanctions or adverse inference instructions when parties fail to honor their
+            preservation duties.
+          </p>
+
+          <h2>Collect Digital and Electronic Data</h2>
+          <p>
+            Modern accidents generate digital footprints. Commercial vehicles contain electronic logging devices, GPS trackers,
+            and dash cameras. Industrial machinery may record operating parameters. Buildings often have security cameras that
+            overwrite footage within days. We move quickly to download these files in a forensically sound manner. Our experts
+            extract metadata, verify timestamps, and preserve the original format to maintain authenticity.
+          </p>
+          <p>
+            Personal devices also hold valuable evidence. Smartphones capture photographs, text messages, call logs, and app
+            data. Wearable technology can reveal heart rate, steps taken, or sleep patterns before and after the incident. We
+            instruct clients to avoid deleting content, even if it seems unimportant, until it can be evaluated. When necessary,
+            we obtain court orders to secure third-party data from companies that control social media or cloud storage.
+          </p>
+
+          <h2>Document the Scene Thoroughly</h2>
+          <p>
+            Returning to the scene as soon as it is safe allows us to capture details that may be absent from official reports.
+            We take high-resolution photographs from multiple angles, noting skid marks, debris patterns, lighting conditions,
+            and signage. In premises cases, we document spill locations, lighting levels, and maintenance equipment. Drones and
+            3D laser scanners create precise models of crash sites or industrial facilities. These visualizations become
+            powerful exhibits during mediation and trial.
+          </p>
+          <p>
+            Witness interviews are also part of scene documentation. People who live or work nearby may have observed events
+            before or after the incident. Their accounts often provide context missing from police reports. We obtain contact
+            information and written or recorded statements while memories remain fresh.
+          </p>
+
+          <h2>Coordinate with Government Investigations</h2>
+          <p>
+            Law enforcement agencies, OSHA, the National Transportation Safety Board, or other regulators may conduct their own
+            investigations. We monitor these efforts closely, obtaining reports, citations, and findings when available. While
+            regulatory investigations do not replace our independent work, they often uncover valuable documents or expert
+            analyses. Collaborating respectfully with investigators can provide insight into timelines, witness lists, and key
+            technical issues.
+          </p>
+          <p>
+            When governmental entities control critical evidence, such as a roadway design file or traffic signal timing data,
+            we use public information requests or subpoenas to obtain copies. Persistence is essential; bureaucratic delays can
+            slow the process, but staying engaged ensures nothing falls through the cracks.
+          </p>
+
+          <h2>Preserve Evidence of Damages</h2>
+          <p>
+            Evidence preservation extends beyond liability. We collect medical records, billing statements, and therapy notes to
+            document the injury’s impact. Clients keep journals describing pain levels, emotional struggles, and daily
+            limitations. Family members note caregiving responsibilities and household adjustments. Employers provide statements
+            about missed work, lost promotions, or the need for accommodations. These materials support both economic and non-
+            economic damages claims.
+          </p>
+          <p>
+            Photographs and videos of recovery milestones—from hospital stays to rehabilitation progress—humanize the case.
+            Demonstrating the day-to-day challenges of living with catastrophic injuries helps jurors understand why full
+            compensation is necessary.
+          </p>
+
+          <h2>Address Spoliation Risks</h2>
+          <p>
+            Spoliation occurs when evidence is destroyed or altered. Texas courts can impose sanctions ranging from monetary
+            penalties to jury instructions that presume the missing evidence would have been unfavorable to the spoliator.
+            Documenting our preservation efforts is crucial. We keep copies of all letters, emails, and responses. If a defendant
+            claims evidence was lost due to routine procedures, we evaluate whether they acted reasonably after receiving notice
+            of the claim. Demonstrating diligence strengthens our position when seeking court intervention.
+          </p>
+          <p>
+            We also counsel clients about their own preservation obligations. Deleting social media posts or disposing of
+            damaged property can undermine credibility. Transparency and cooperation with discovery requests demonstrate respect
+            for the legal process and protect the integrity of the case.
+          </p>
+
+          <h2>Prepare for Expert Analysis</h2>
+          <p>
+            Preserved evidence has limited value without expert interpretation. We plan inspections that allow both sides to
+            observe testing procedures, minimizing disputes about methodology. Experts create detailed reports, photographs, and
+            diagrams explaining their findings. When multiple experts need access to the same evidence, we schedule sequential
+            inspections to maintain chain of custody. Organized management of evidence keeps the case moving smoothly and avoids
+            surprises as trial approaches.
+          </p>
+          <p>
+            In some cases, we construct replicas or models to facilitate testing without risking damage to original evidence.
+            For example, engineers may recreate a section of roadway or a piece of machinery to demonstrate failure modes. These
+            efforts ensure the original exhibits remain intact for courtroom presentation.
+          </p>
+
+          <h2>Engage Community and Support Resources</h2>
+          <p>
+            Catastrophic events often affect more than the immediate family. Nearby residents, coworkers, or first responders
+            may have photographs, video clips, or observations that become invaluable. We establish respectful lines of
+            communication with these community members, explaining how their cooperation contributes to a safer environment for
+            everyone. Coordinating neighborhood meetings or workplace debriefs can surface additional evidence that official
+            reports overlooked.
+          </p>
+          <p>
+            Support organizations also play a role. Victim advocates, faith leaders, or nonprofit groups sometimes assist with
+            documenting needs, providing counseling records, or helping families maintain organized logs. Preserving this
+            information adds depth to damages claims by illustrating the broader ripple effects of negligence. When evidence
+            preservation becomes a collaborative effort, the resulting case more accurately reflects the community’s pursuit of
+            accountability and the resilience that follows tragedy.
+          </p>
+
+          <h2>Conclusion</h2>
+          <p>
+            Preserving evidence after a catastrophic accident is a race against time. By prioritizing medical care, engaging
+            counsel early, issuing preservation letters, securing physical and digital evidence, and coordinating expert
+            analysis, injured individuals protect their right to justice. The truth of what happened deserves to be heard, and
+            meticulous evidence preservation gives jurors the tools they need to deliver a fair verdict. Families navigating the
+            aftermath of tragedy can take comfort in knowing that proactive steps today will strengthen their case tomorrow.
+          </p>
+        </div>
+      </article>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>&copy; <span id="year"></span> James Kennedy, P.L.L.C. All rights reserved.</p>
+        <div class="footer-links">
+          <a href="../index.html#about">About</a>
+          <a href="../index.html#practice-areas">Practice Areas</a>
+          <a href="index.html">Blog</a>
+          <a href="../contact.html">Contact</a>
+          <a href="../privacy-policy.html">Privacy Policy</a>
+          <a href="../disclaimer.html">Disclaimer</a>
+        </div>
+      </div>
+    </footer>
+
+    <div class="cookie-banner" id="cookie-banner" role="dialog" aria-live="polite">
+      <div class="container cookie-banner__inner">
+        <p>
+          This website uses cookies to analyze site traffic and improve your experience. By
+          clicking “Accept,” you consent to the use of cookies in accordance with our
+          <a href="../privacy-policy.html">Privacy Policy</a>.
+        </p>
+        <button class="btn primary" id="cookie-accept" type="button">Accept</button>
+      </div>
+    </div>
+
+    <script src="../assets/js/main.js"></script>
+  </body>
+</html>

--- a/blog/wrongful-death-claims-texas.html
+++ b/blog/wrongful-death-claims-texas.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>What Families Should Know About Wrongful Death Claims | James B. Kennedy, Jr.</title>
+    <meta
+      name="description"
+      content="James B. Kennedy, Jr. offers a 1,500-word guide for Texas families pursuing wrongful death claims after negligence takes a loved one’s life."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600&family=Work+Sans:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/css/styles.css" />
+  </head>
+  <body class="interior-page">
+    <header class="site-header">
+      <div class="container">
+        <div class="branding">
+          <div class="logo">JK</div>
+          <div class="identity">
+            <span class="name">James B. Kennedy, Jr.</span>
+            <span class="tagline">Personal Injury Trial Lawyer</span>
+          </div>
+        </div>
+        <a class="cta-pill" href="tel:9155445200">Call 915-544-5200</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="article-hero">
+        <div class="container narrow">
+          <p class="eyebrow">Texas Wrongful Death Law</p>
+          <h1>What Families Should Know About Wrongful Death Claims</h1>
+          <div class="article-meta">
+            <span>By James B. Kennedy, Jr.</span>
+            <span>Supporting Families Seeking Accountability</span>
+            <span>Approx. 1,500 words</span>
+          </div>
+        </div>
+      </section>
+
+      <article class="article-content">
+        <div class="container narrow">
+          <p>
+            Losing a loved one to someone else’s negligence is a tragedy that reverberates through every corner of a
+            family’s life. No legal action can replace the presence, wisdom, or companionship of the person who is gone.
+            Still, wrongful death claims provide a path to accountability, financial stability, and community safety.
+            Families confronted with sudden loss often feel overwhelmed by grief, medical bills, funeral expenses, and
+            unanswered questions. As a trial lawyer based in El Paso, I have walked alongside many families during these
+            heartbreaking moments. This guide explains how wrongful death claims work in Texas, who can file them, what
+            damages are available, and how the process unfolds.
+          </p>
+
+          <h2>Understanding the Difference Between Wrongful Death and Survival Claims</h2>
+          <p>
+            Texas recognizes two distinct causes of action when negligence causes death: wrongful death and survival. A
+            wrongful death claim belongs to the statutory beneficiaries—the surviving spouse, children, and parents of the
+            decedent. It compensates them for the harm they personally experience because of the loss. A survival action,
+            by contrast, belongs to the decedent’s estate and seeks damages the deceased person could have recovered had
+            they survived, such as medical bills and pain experienced before passing. Both claims can be pursued
+            simultaneously, but they involve different beneficiaries and damages categories. Understanding this distinction
+            helps families set expectations and plan for estate administration if necessary.
+          </p>
+          <p>
+            Some families worry that filing a lawsuit feels adversarial or inconsistent with their loved one’s values. I
+            remind them that wrongful death statutes exist to protect communities and deter dangerous behavior. Holding
+            negligent parties accountable can prevent other families from suffering the same fate. Additionally, these
+            claims provide the financial resources needed to cover expenses, support children, and honor the decedent’s
+            legacy through scholarships, charitable donations, or other memorials.
+          </p>
+
+          <h2>Determining Eligibility to File a Wrongful Death Claim</h2>
+          <p>
+            Texas law limits who may bring a wrongful death suit. The surviving spouse, biological and legally adopted
+            children, and parents of the deceased have standing. Siblings, grandparents, and more distant relatives are not
+            eligible. If none of the eligible relatives file within three months of the death, the executor or administrator
+            of the estate may pursue the claim unless a family member specifically requests otherwise. We work closely with
+            families to confirm relationships, obtain necessary documentation, and ensure everyone understands their role
+            in the litigation.
+          </p>
+          <p>
+            In blended families, determining standing can raise unique questions. Adopted children have the same rights as
+            biological children. Stepchildren do not unless legally adopted. Common-law spouses must prove the marriage to
+            establish standing. When disputes arise, we approach them with sensitivity, focusing on honoring the decedent’s
+            intentions while following the statute.
+          </p>
+
+          <h2>Identifying the Statute of Limitations and Key Deadlines</h2>
+          <p>
+            Generally, wrongful death claims in Texas must be filed within two years of the date of death. Certain
+            circumstances—such as cases involving governmental entities, minors, or fraudulent concealment—may affect the
+            deadline. Because evidence fades and witnesses’ memories diminish over time, we encourage families to begin the
+            legal process as soon as they feel ready. Early action allows us to preserve evidence, investigate thoroughly,
+            and navigate probate issues that might delay filing.
+          </p>
+          <p>
+            In addition to the statute of limitations, there may be notice requirements for claims involving governmental
+            agencies or healthcare providers. Missing these deadlines can jeopardize the case. Our firm tracks all relevant
+            timelines, files notices promptly, and ensures the lawsuit is filed in the proper venue.
+          </p>
+
+          <h2>Investigating Liability and Gathering Evidence</h2>
+          <p>
+            Proving liability in a wrongful death case requires the same thorough investigation as any catastrophic injury
+            claim. We collect police reports, accident reconstructions, medical records, product testing data, or workplace
+            safety documents depending on the circumstances. Witness interviews, surveillance footage, and expert testimony
+            often play central roles. In medical negligence cases, we consult with specialists to evaluate standards of care.
+            In trucking or industrial incidents, we scrutinize corporate safety policies, maintenance logs, and regulatory
+            compliance. Our goal is to uncover the full story of what went wrong and present it clearly to the jury.
+          </p>
+          <p>
+            Preserving evidence quickly is critical. Vehicles, defective products, and industrial equipment may be repaired
+            or discarded unless we intervene with preservation letters or court orders. We also advise families to safeguard
+            their loved one’s personal belongings, digital devices, and social media accounts, which may contain valuable
+            information. Building a strong liability case honors the decedent by telling the truth about the preventable
+            circumstances that led to their passing.
+          </p>
+
+          <h2>Documenting Economic Losses</h2>
+          <p>
+            Wrongful death damages include the financial support the decedent would have provided to the family. Economists
+            analyze the decedent’s earnings history, career trajectory, benefits, and household contributions. For
+            stay-at-home parents, we calculate the market value of childcare, transportation, household management, and other
+            services they provided. If the decedent supported aging parents or extended family members, we document those
+            contributions as well.
+          </p>
+          <p>
+            Funeral and burial expenses are also recoverable. We gather invoices from funeral homes, cemeteries, and service
+            providers. These immediate costs can be significant, and compensation eases the financial strain during a period
+            of mourning. In survival claims, we also seek reimbursement for medical bills incurred between the injury and the
+            decedent’s passing.
+          </p>
+
+          <h2>Honoring Non-Economic Losses</h2>
+          <p>
+            The heart of a wrongful death claim lies in non-economic damages: loss of companionship, emotional anguish,
+            mental pain, and the absence of guidance a loved one provided. Sharing the decedent’s life story humanizes the
+            case. We gather photos, videos, letters, and journal entries that illustrate relationships. Family members,
+            friends, coworkers, coaches, and spiritual leaders offer testimony about the decedent’s character, dreams, and
+            daily interactions. Jurors need to see the person behind the name in the caption to appreciate the magnitude of
+            the loss.
+          </p>
+          <p>
+            Grief counseling records or mental health treatment notes may further demonstrate the emotional toll on
+            surviving family members. While these damages cannot be calculated with a formula, thoughtful storytelling helps
+            jurors understand the immeasurable harm caused by negligence. We encourage families to speak openly about their
+            grief, their resilience, and the ways they continue to honor their loved one’s memory.
+          </p>
+
+          <h2>Considering Exemplary Damages</h2>
+          <p>
+            Texas allows exemplary (punitive) damages in wrongful death cases when the defendant’s conduct reflects gross
+            negligence, malice, or willful wrongdoing. Examples include drunk driving fatalities, knowingly defective
+            products, or employers who ignore catastrophic safety hazards. Pursuing exemplary damages requires clear and
+            convincing evidence. We gather internal documents, safety audits, prior incident reports, and expert opinions to
+            demonstrate conscious indifference. Exemplary damages not only increase potential recovery but also send a
+            powerful message that the community will not tolerate reckless behavior.
+          </p>
+
+          <h2>Navigating Probate and Estate Issues</h2>
+          <p>
+            Wrongful death cases often intersect with probate law. If a survival claim is pursued, an estate must be opened
+            to appoint a personal representative. We assist families in initiating probate proceedings, gathering necessary
+            documents, and ensuring the estate’s interests are protected. When settlements involve minors or structured
+            payments, court approval may be required. Coordinating personal injury litigation with probate prevents delays
+            and safeguards everyone’s rights.
+          </p>
+          <p>
+            Estate planning considerations also arise when distributing settlement proceeds. We collaborate with probate
+            counsel and financial advisors to structure agreements that reflect the family’s priorities, minimize tax
+            consequences, and provide long-term stability. Transparent communication between family members reduces the risk
+            of conflicts.
+          </p>
+
+          <h2>Preparing for Litigation and Trial</h2>
+          <p>
+            Some wrongful death claims resolve through settlement, while others require trial. Regardless of the path, we
+            prepare diligently from day one. Discovery allows us to depose witnesses, request documents, and analyze expert
+            opinions. Mediation can provide a forum for meaningful negotiations, but we never compromise our readiness for
+            court. In the courtroom, we present a narrative that honors the decedent, exposes the defendant’s misconduct, and
+            articulates the family’s losses. Visual exhibits, timelines, and day-in-the-life videos help jurors connect with
+            the story.
+          </p>
+          <p>
+            Families play an essential role in this process. We prepare them for depositions and trial testimony, ensuring
+            they feel supported and empowered. Sharing memories, even painful ones, becomes a way to give voice to the loved
+            one who cannot speak. Jurors respond to authenticity, compassion, and courage.
+          </p>
+
+          <h2>Providing Compassionate Support Throughout the Process</h2>
+          <p>
+            Beyond legal strategy, we prioritize compassion. Families grieving a wrongful death need space to mourn, manage
+            logistics, and support one another. Our team coordinates with grief counselors, faith leaders, and support
+            groups. We handle communication with insurance companies, creditors, and investigators so families can focus on
+            healing. Regular updates, plain-language explanations, and responsive communication build trust during an
+            emotionally exhausting journey.
+          </p>
+          <p>
+            After a case resolves, we remain available to assist with lien resolution, trust administration, and ongoing
+            questions. Many families continue to advocate for safety reforms, scholarships, or charitable initiatives in the
+            decedent’s name. We are honored to support those efforts whenever possible.
+          </p>
+
+          <h2>Conclusion</h2>
+          <p>
+            Wrongful death claims are about more than financial recovery. They provide a mechanism for families to uncover
+            the truth, demand accountability, and secure resources for the future. By understanding eligibility, timelines,
+            damages, and the litigation process, families can make informed decisions during a profoundly difficult time.
+            Experienced legal counsel ensures the case is handled with the dignity, care, and tenacity it deserves. While no
+            verdict can fill the absence left behind, pursuing justice honors the loved one’s memory and helps protect the
+            community from similar tragedies.
+          </p>
+        </div>
+      </article>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>&copy; <span id="year"></span> James Kennedy, P.L.L.C. All rights reserved.</p>
+        <div class="footer-links">
+          <a href="../index.html#about">About</a>
+          <a href="../index.html#practice-areas">Practice Areas</a>
+          <a href="index.html">Blog</a>
+          <a href="../contact.html">Contact</a>
+          <a href="../privacy-policy.html">Privacy Policy</a>
+          <a href="../disclaimer.html">Disclaimer</a>
+        </div>
+      </div>
+    </footer>
+
+    <div class="cookie-banner" id="cookie-banner" role="dialog" aria-live="polite">
+      <div class="container cookie-banner__inner">
+        <p>
+          This website uses cookies to analyze site traffic and improve your experience. By
+          clicking “Accept,” you consent to the use of cookies in accordance with our
+          <a href="../privacy-policy.html">Privacy Policy</a>.
+        </p>
+        <button class="btn primary" id="cookie-accept" type="button">Accept</button>
+      </div>
+    </div>
+
+    <script src="../assets/js/main.js"></script>
+  </body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Contact James B. Kennedy, Jr. | Personal Injury Attorney</title>
+    <meta
+      name="description"
+      content="Reach out to El Paso personal injury lawyer James B. Kennedy, Jr. for a free consultation about your serious accident or wrongful death case."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600&family=Work+Sans:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body class="interior-page">
+    <header class="site-header">
+      <div class="container">
+        <div class="branding">
+          <div class="logo">JK</div>
+          <div class="identity">
+            <span class="name">James B. Kennedy, Jr.</span>
+            <span class="tagline">Personal Injury Trial Lawyer</span>
+          </div>
+        </div>
+        <a class="cta-pill" href="tel:9155445200">Call 915-544-5200</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="page-hero">
+        <div class="container narrow">
+          <p class="eyebrow">Schedule a Free Consultation</p>
+          <h1>Contact James Kennedy, P.L.L.C.</h1>
+          <p class="lead">
+            Whether you have questions about a recent accident or are ready to take action, our
+            team is here to listen, evaluate your claim, and map out the next steps.
+          </p>
+        </div>
+      </section>
+
+      <section class="contact-detail">
+        <div class="container split">
+          <div class="contact-info-card">
+            <h2>Visit or Call the El Paso Office</h2>
+            <p>
+              James welcomes clients from across Texas, New Mexico, Colorado, Arizona, and Nevada.
+              Reach out using the contact details below or send a message through the secure form.
+            </p>
+            <div class="contact-details">
+              <div>
+                <span class="label">Phone</span>
+                <a href="tel:9155445200">915-544-5200</a>
+              </div>
+              <div>
+                <span class="label">Fax</span>
+                <a href="tel:9155445201">915-544-5201</a>
+              </div>
+              <div>
+                <span class="label">Email</span>
+                <a href="mailto:info@jameskennedypllc.com">info@jameskennedypllc.com</a>
+              </div>
+              <div>
+                <span class="label">Office</span>
+                <p>6216 Gateway Blvd. East<br />El Paso, TX 79905</p>
+              </div>
+              <div>
+                <span class="label">Hours</span>
+                <p>Monday &ndash; Friday: 8:00 AM &ndash; 6:00 PM<br />Saturday: 9:00 AM &ndash; 1:00 PM<br />Sunday: Closed</p>
+              </div>
+            </div>
+            <div class="service-areas">
+              <h3>Service Areas</h3>
+              <p>
+                We primarily represent people hurt in trucking collisions, workplace incidents,
+                product failures, and other catastrophic events in West Texas and Southern New
+                Mexico. Select cases are considered throughout the broader Southwest.
+              </p>
+            </div>
+          </div>
+          <div class="contact-form-card" id="contact-form">
+            <h2>Send a Secure Message</h2>
+            <p>
+              Provide as much detail as you feel comfortable sharing. Our team will reach out as
+              soon as possible to discuss your situation and arrange a consultation.
+            </p>
+            <form>
+              <div class="field-grid">
+                <label>
+                  First Name
+                  <input type="text" name="first_name" placeholder="First name" required />
+                </label>
+                <label>
+                  Last Name
+                  <input type="text" name="last_name" placeholder="Last name" required />
+                </label>
+              </div>
+              <label>
+                Phone Number
+                <input type="tel" name="phone" placeholder="(###) ###-####" required />
+              </label>
+              <label>
+                Email Address
+                <input type="email" name="email" placeholder="you@example.com" required />
+              </label>
+              <label>
+                Preferred Contact Method
+                <select name="contact_method">
+                  <option value="phone">Phone</option>
+                  <option value="email">Email</option>
+                  <option value="either">Either</option>
+                </select>
+              </label>
+              <label>
+                How can we help?
+                <textarea name="message" rows="6" placeholder="Describe what happened"></textarea>
+              </label>
+              <p class="disclaimer">
+                Submitting this form does not create an attorney-client relationship. Please do not
+                send confidential or time-sensitive information until an engagement agreement is
+                executed.
+              </p>
+              <button type="submit" class="btn primary" disabled>Submit (Coming Soon)</button>
+            </form>
+          </div>
+        </div>
+      </section>
+
+      <section class="map-section">
+        <div class="container">
+          <h2>Find Us</h2>
+          <p>
+            The office is conveniently located near I-10 in East-Central El Paso with ample
+            parking. Virtual appointments are available for clients outside the immediate region.
+          </p>
+          <div class="map-placeholder" role="img" aria-label="Map placeholder showing office location">
+            <span>Interactive map coming soon</span>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>&copy; <span id="year"></span> James Kennedy, P.L.L.C. All rights reserved.</p>
+        <div class="footer-links">
+          <a href="index.html#about">About</a>
+          <a href="index.html#practice-areas">Practice Areas</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html" class="active">Contact</a>
+          <a href="privacy-policy.html">Privacy Policy</a>
+          <a href="disclaimer.html">Disclaimer</a>
+        </div>
+      </div>
+    </footer>
+
+    <div class="cookie-banner" id="cookie-banner" role="dialog" aria-live="polite">
+      <div class="container cookie-banner__inner">
+        <p>
+          This website uses cookies to analyze site traffic and improve your experience. By
+          clicking “Accept,” you consent to the use of cookies in accordance with our
+          <a href="privacy-policy.html">Privacy Policy</a>.
+        </p>
+        <button class="btn primary" id="cookie-accept" type="button">Accept</button>
+      </div>
+    </div>
+
+    <script src="assets/js/main.js"></script>
+  </body>
+</html>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Disclaimer | James B. Kennedy, Jr.</title>
+    <meta
+      name="description"
+      content="Legal disclaimer for James Kennedy, P.L.L.C. outlining informational purposes, attorney-client relationship, and advertising disclosures."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600&family=Work+Sans:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body class="interior-page">
+    <header class="site-header">
+      <div class="container">
+        <div class="branding">
+          <div class="logo">JK</div>
+          <div class="identity">
+            <span class="name">James B. Kennedy, Jr.</span>
+            <span class="tagline">Personal Injury Trial Lawyer</span>
+          </div>
+        </div>
+        <a class="cta-pill" href="tel:9155445200">Call 915-544-5200</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="page-hero">
+        <div class="container narrow">
+          <p class="eyebrow">Important Information</p>
+          <h1>Disclaimer</h1>
+          <p class="lead">
+            Please review the following statements about this website, attorney advertising, and the
+            limits of the information provided by James Kennedy, P.L.L.C.
+          </p>
+        </div>
+      </section>
+
+      <section class="policy-section">
+        <div class="container narrow">
+          <h2>Informational Purposes Only</h2>
+          <p>
+            The content on this Site is provided for general informational purposes and should not be
+            construed as legal advice on any subject matter. Visitors should not act upon any
+            information contained on the Site without first seeking professional counsel licensed in
+            their jurisdiction.
+          </p>
+
+          <h2>No Attorney-Client Relationship</h2>
+          <p>
+            Use of this Site, including the contact form, email links, or other communication tools,
+            does not create an attorney-client relationship between you and James Kennedy, P.L.L.C.
+            An attorney-client relationship is formed only after the firm has evaluated your matter,
+            conflicts have been cleared, and a written engagement agreement has been executed.
+          </p>
+
+          <h2>Confidentiality</h2>
+          <p>
+            Do not send confidential or time-sensitive information through this Site. Any information
+            transmitted via the Site or over the internet may not be secure. We take reasonable steps
+            to protect your data, but cannot guarantee the security of electronic transmissions.
+          </p>
+
+          <h2>Advertising Notice</h2>
+          <p>
+            This Site may be considered attorney advertising in certain jurisdictions. Prior results
+            do not guarantee a similar outcome. Every case is unique and must be evaluated on its own
+            facts and applicable law.
+          </p>
+
+          <h2>Third-Party Links</h2>
+          <p>
+            The Site may contain links to third-party websites. These links are provided solely for
+            convenience and informational purposes. We do not endorse, sponsor, or otherwise approve
+            of the content on third-party sites and are not responsible for their privacy practices or
+            terms of use.
+          </p>
+
+          <h2>Updates to This Disclaimer</h2>
+          <p>
+            We may revise this Disclaimer at any time without prior notice. Changes will be posted on
+            this page, and the updated date below will reflect the effective date of the revision.
+          </p>
+
+          <h2>Contact Information</h2>
+          <p>
+            Questions about this Disclaimer should be directed to James Kennedy, P.L.L.C., 6216
+            Gateway Blvd. East, El Paso, TX 79905, or by phone at <a href="tel:9155445200">915-544-5200</a>.
+          </p>
+
+          <p class="last-updated">Last updated: April 5, 2024</p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>&copy; <span id="year"></span> James Kennedy, P.L.L.C. All rights reserved.</p>
+        <div class="footer-links">
+          <a href="index.html#about">About</a>
+          <a href="index.html#practice-areas">Practice Areas</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html">Contact</a>
+          <a href="privacy-policy.html">Privacy Policy</a>
+          <a href="disclaimer.html" class="active">Disclaimer</a>
+        </div>
+      </div>
+    </footer>
+
+    <div class="cookie-banner" id="cookie-banner" role="dialog" aria-live="polite">
+      <div class="container cookie-banner__inner">
+        <p>
+          This website uses cookies to analyze site traffic and improve your experience. By
+          clicking “Accept,” you consent to the use of cookies in accordance with our
+          <a href="privacy-policy.html">Privacy Policy</a>.
+        </p>
+        <button class="btn primary" id="cookie-accept" type="button">Accept</button>
+      </div>
+    </div>
+
+    <script src="assets/js/main.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,365 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>James B. Kennedy, Jr. | Personal Injury Trial Lawyer</title>
+    <meta
+      name="description"
+      content="Board-certified El Paso personal injury attorney James Bryce Kennedy, Jr. helps victims across Texas, New Mexico, Arizona, Colorado, and Nevada fight for justice."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600&family=Work+Sans:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container">
+        <div class="branding">
+          <div class="logo">JK</div>
+          <div class="identity">
+            <span class="name">James B. Kennedy, Jr.</span>
+            <span class="tagline">Personal Injury Trial Lawyer</span>
+          </div>
+        </div>
+        <nav class="site-nav" id="site-nav">
+          <a href="index.html#about">About</a>
+          <a href="index.html#practice-areas">Practice Areas</a>
+          <a href="index.html#experience">Experience</a>
+          <a href="index.html#admissions">Credentials</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html">Contact</a>
+          <a href="privacy-policy.html">Privacy Policy</a>
+          <a href="disclaimer.html">Disclaimer</a>
+        </nav>
+        <button class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+        <a class="cta-pill" href="tel:9155445200">Call 915-544-5200</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="container">
+          <div class="hero-content">
+            <p class="eyebrow">Board-Certified Personal Injury Advocate</p>
+            <h1>Fighting for the injured across West Texas and the Southwest</h1>
+            <p class="lead">
+              James Bryce Kennedy, Jr. has been standing up for individuals and families since
+              1994. From catastrophic injuries and trucking crashes to insurance bad faith,
+              he pairs courtroom experience with compassionate, client-centered guidance.
+            </p>
+            <div class="hero-actions">
+              <a class="btn primary" href="tel:9155445200">Free Consultation</a>
+              <a class="btn secondary" href="contact.html#contact-form">Message the Firm</a>
+            </div>
+            <ul class="hero-highlights">
+              <li>Board Certified in Personal Injury Trial Law (TBLS)</li>
+              <li>Serving Texas, Colorado, New Mexico, Arizona &amp; Nevada</li>
+              <li>Se habla Español</li>
+            </ul>
+          </div>
+          <div class="hero-card">
+            <div class="hero-card-inner">
+              <h2>Why Clients Choose James</h2>
+              <ul>
+                <li>Three decades of trial-tested experience</li>
+                <li>No attorney fees unless a recovery is made</li>
+                <li>Direct access to your attorney from day one</li>
+                <li>Strategic litigation for serious injury cases</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="about" class="about">
+        <div class="container split">
+          <div class="about-text">
+            <h2>Meet James B. Kennedy, Jr.</h2>
+            <p>
+              James is the founder and primary owner of <strong>James Kennedy, P.L.L.C.</strong> in El Paso,
+              Texas. He is a seasoned trial attorney known for handling complex personal injury,
+              wrongful death, work-related injury, and products liability cases. Licensed in five
+              states and fluent in both English and Spanish, James guides clients through the
+              legal system with skill and empathy.
+            </p>
+            <p>
+              After graduating <em>cum laude</em> from Texas Tech University School of Law in 1994, James
+              built his career representing injured individuals against powerful corporations and
+              insurance companies. He continues to try cases across the Southwest, drawing on his
+              board certification and deep understanding of catastrophic injury litigation.
+            </p>
+          </div>
+          <div class="about-credentials">
+            <div class="credential">
+              <span class="label">In Practice Since</span>
+              <span class="value">1994</span>
+            </div>
+            <div class="credential">
+              <span class="label">Languages</span>
+              <span class="value">English &amp; Spanish</span>
+            </div>
+            <div class="credential">
+              <span class="label">Licensed States</span>
+              <span class="value">TX, NM, CO, AZ, NV</span>
+            </div>
+            <div class="credential">
+              <span class="label">Consultations</span>
+              <span class="value">Free initial meeting</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="practice-areas" class="practice-areas">
+        <div class="container">
+          <h2>Focused on Serious Injury &amp; Wrongful Death Cases</h2>
+          <p class="section-lead">
+            James represents people who have suffered life-changing harm because of another's
+            negligence, defective products, or corporate misconduct.
+          </p>
+          <div class="practice-grid">
+            <article class="practice-card">
+              <h3>Personal Injury Litigation</h3>
+              <p>Catastrophic injuries, traumatic brain injuries, spinal cord damage, and burns.</p>
+            </article>
+            <article class="practice-card">
+              <h3>Vehicle &amp; Truck Crashes</h3>
+              <p>18-wheeler, car, motorcycle, bus, and public transportation collisions.</p>
+            </article>
+            <article class="practice-card">
+              <h3>Workplace &amp; Industrial Accidents</h3>
+              <p>Oil and gas, refinery, construction, and other work-related injury claims.</p>
+            </article>
+            <article class="practice-card">
+              <h3>Premises Liability</h3>
+              <p>Unsafe properties, slips and falls, apartment and amusement park injuries.</p>
+            </article>
+            <article class="practice-card">
+              <h3>Defective &amp; Dangerous Products</h3>
+              <p>Product defects, tire failures, and unsafe equipment causing serious harm.</p>
+            </article>
+            <article class="practice-card">
+              <h3>Insurance Bad Faith</h3>
+              <p>Holding insurers accountable when they delay, deny, or underpay valid claims.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="experience" class="experience">
+        <div class="container split">
+          <div>
+            <h2>Decades of Trial Experience</h2>
+            <p>
+              From his own firm to respected litigation boutiques, James has dedicated his career
+              to building powerful cases on behalf of injured clients.
+            </p>
+            <ul class="timeline">
+              <li>
+                <div class="timeline-year">2000 &ndash; Present</div>
+                <div class="timeline-body">
+                  <h3>James Kennedy, P.L.L.C.</h3>
+                  <p>Founder and lead trial attorney representing injury victims across the Southwest.</p>
+                </div>
+              </li>
+              <li>
+                <div class="timeline-year">2000 &ndash; 2003</div>
+                <div class="timeline-body">
+                  <h3>Guage &amp; Kennedy, P.L.L.C.</h3>
+                  <p>Personal injury attorney focused on complex civil litigation.</p>
+                </div>
+              </li>
+              <li>
+                <div class="timeline-year">1994 &ndash; 2000</div>
+                <div class="timeline-body">
+                  <h3>Scherr, Legate &amp; Ehrlich, P.L.L.C.</h3>
+                  <p>Trial lawyer advocating for plaintiffs in catastrophic injury cases.</p>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div class="experience-cta">
+            <div class="quote-card">
+              <p>
+                "Local, board-certified attorney James B. Kennedy will walk into the courtroom
+                with you and fight for the justice you deserve."
+              </p>
+              <a class="btn primary" href="tel:9155445200">Speak with James today</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="admissions" class="credentials">
+        <div class="container split">
+          <div>
+            <h2>Credentials &amp; Admissions</h2>
+            <p>
+              James is admitted to practice in multiple state and federal courts, giving clients
+              the flexibility to pursue justice wherever their case leads.
+            </p>
+            <div class="credential-lists">
+              <div>
+                <h3>State &amp; Federal Courts</h3>
+                <ul>
+                  <li>Texas &mdash; 1994</li>
+                  <li>U.S. District Court, Western District of Texas &mdash; 1995</li>
+                  <li>New Mexico State Courts &mdash; 1995</li>
+                  <li>U.S. District Court, District of New Mexico &mdash; 1999</li>
+                  <li>U.S. Court of Appeals for the Tenth Circuit &mdash; 2000</li>
+                  <li>Colorado &mdash; 2004</li>
+                  <li>Nevada &mdash; 2004</li>
+                  <li>U.S. District Court, District of Nevada &mdash; 2006</li>
+                  <li>Arizona &mdash; 2014</li>
+                </ul>
+              </div>
+              <div>
+                <h3>Board Certification</h3>
+                <ul>
+                  <li>Texas Board of Legal Specialization &mdash; Personal Injury Trial Law (2003)</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="education">
+            <h2>Education</h2>
+            <ul>
+              <li>
+                <span class="degree">Juris Doctor, cum laude</span>
+                <span class="school">Texas Tech University School of Law, 1994</span>
+              </li>
+              <li>
+                <span class="degree">Bachelor of Arts, Special Honors</span>
+                <span class="school">University of Texas at Austin (History &amp; Government), 1991</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="values">
+        <div class="container">
+          <h2>A Strategic, Client-First Approach</h2>
+          <div class="values-grid">
+            <article>
+              <h3>Hands-On Representation</h3>
+              <p>
+                Clients work directly with James from intake through trial preparation. Every case
+                receives tailored strategy and meticulous attention to detail.
+              </p>
+            </article>
+            <article>
+              <h3>Trial-Ready Preparation</h3>
+              <p>
+                By preparing every file as if it will go before a jury, James positions clients for
+                meaningful settlements and successful verdicts.
+              </p>
+            </article>
+            <article>
+              <h3>Community Commitment</h3>
+              <p>
+                Based in El Paso, James proudly serves West Texas, Southern New Mexico, and
+                communities throughout the Southwest who need a relentless advocate.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="contact" class="contact">
+        <div class="container split">
+          <div class="contact-info">
+            <h2>Schedule Your Free Consultation</h2>
+            <p>
+              Call today to discuss your case with James. No attorney fees are charged unless a
+              recovery is made for you and your family.
+            </p>
+            <div class="contact-details">
+              <div>
+                <span class="label">Phone</span>
+                <a href="tel:9155445200">915-544-5200</a>
+              </div>
+              <div>
+                <span class="label">Office</span>
+                <p>6216 Gateway Blvd. East<br />El Paso, TX 79905</p>
+              </div>
+              <div>
+                <span class="label">Hours</span>
+                <p>Monday &ndash; Friday: 8:00 AM &ndash; 6:00 PM<br />Saturday: 9:00 AM &ndash; 1:00 PM<br />Sunday: Closed</p>
+              </div>
+              <div>
+                <span class="label">Service Areas</span>
+                <p>
+                  Serving clients across West Texas, Southern New Mexico, and select cases in
+                  Arizona, Colorado, and Nevada.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div class="contact-form">
+            <h3>Send a Message</h3>
+            <form>
+              <label>
+                Name
+                <input type="text" name="name" placeholder="Full name" required />
+              </label>
+              <label>
+                Phone
+                <input type="tel" name="phone" placeholder="(###) ###-####" required />
+              </label>
+              <label>
+                Email
+                <input type="email" name="email" placeholder="you@example.com" required />
+              </label>
+              <label>
+                How can James help?
+                <textarea name="message" rows="4" placeholder="Briefly describe your case"></textarea>
+              </label>
+              <p class="disclaimer">
+                Submitting this form does not create an attorney-client relationship. Please avoid
+                sharing confidential information until an engagement agreement is signed.
+              </p>
+              <button type="submit" class="btn primary" disabled>Submit (Coming Soon)</button>
+            </form>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>&copy; <span id="year"></span> James Kennedy, P.L.L.C. All rights reserved.</p>
+        <div class="footer-links">
+          <a href="index.html#about">About</a>
+          <a href="index.html#practice-areas">Practice Areas</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html">Contact</a>
+          <a href="privacy-policy.html">Privacy Policy</a>
+          <a href="disclaimer.html">Disclaimer</a>
+        </div>
+      </div>
+    </footer>
+
+    <div class="cookie-banner" id="cookie-banner" role="dialog" aria-live="polite">
+      <div class="container cookie-banner__inner">
+        <p>
+          This website uses cookies to analyze site traffic and improve your experience. By
+          clicking “Accept,” you consent to the use of cookies in accordance with our
+          <a href="privacy-policy.html">Privacy Policy</a>.
+        </p>
+        <button class="btn primary" id="cookie-accept" type="button">Accept</button>
+      </div>
+    </div>
+
+    <script src="assets/js/main.js"></script>
+  </body>
+</html>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Privacy Policy | James B. Kennedy, Jr.</title>
+    <meta
+      name="description"
+      content="Privacy policy detailing how James Kennedy, P.L.L.C. collects, uses, and protects visitor information on this website."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600&family=Work+Sans:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body class="interior-page">
+    <header class="site-header">
+      <div class="container">
+        <div class="branding">
+          <div class="logo">JK</div>
+          <div class="identity">
+            <span class="name">James B. Kennedy, Jr.</span>
+            <span class="tagline">Personal Injury Trial Lawyer</span>
+          </div>
+        </div>
+        <a class="cta-pill" href="tel:9155445200">Call 915-544-5200</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="page-hero">
+        <div class="container narrow">
+          <p class="eyebrow">Privacy Practices</p>
+          <h1>Privacy Policy</h1>
+          <p class="lead">
+            Learn how James Kennedy, P.L.L.C. collects, uses, and protects the personal information
+            you share when visiting this website.
+          </p>
+        </div>
+      </section>
+
+      <section class="policy-section">
+        <div class="container narrow">
+          <h2>Introduction</h2>
+          <p>
+            James Kennedy, P.L.L.C. ("we," "us," or "our") respects your privacy and is committed
+            to protecting any personal information you share with us. This Privacy Policy explains
+            what information we collect when you visit jameskennedypllc.com (the "Site"), how we use
+            that information, and the choices you have. By using the Site, you consent to the data
+            practices described below.
+          </p>
+
+          <h2>Information We Collect</h2>
+          <p>
+            We may collect personal information that you voluntarily provide, such as your name,
+            phone number, email address, and case details when you complete a contact form, request
+            a consultation, or subscribe to updates. We also automatically collect certain technical
+            information, including your IP address, browser type, referring pages, and the date and
+            time of each visit. This information helps us understand how the Site is used and
+            improve its performance.
+          </p>
+
+          <h2>How We Use Information</h2>
+          <p>
+            The information we collect is used to respond to your inquiries, schedule consultations,
+            and provide legal marketing communications that may be of interest. We also use data to
+            maintain and improve the Site, analyze traffic patterns, and ensure security. We do not
+            sell or rent your personal information to third parties.
+          </p>
+
+          <h2>Cookies and Tracking Technologies</h2>
+          <p>
+            The Site uses cookies and similar tracking technologies to recognize your browser,
+            capture information about your interaction with our content, and measure campaign
+            performance. Cookies are small data files stored on your device that help us customize
+            your experience. You can adjust your browser settings to refuse cookies or alert you
+            when cookies are being sent. However, disabling cookies may affect the functionality of
+            some features.
+          </p>
+
+          <h2>Third-Party Services</h2>
+          <p>
+            We may partner with service providers to host the Site, manage email communications,
+            analyze usage trends, or facilitate online chat features. These providers have access to
+            personal information only as necessary to perform their services and are obligated to
+            protect your data in accordance with our instructions.
+          </p>
+
+          <h2>Data Security</h2>
+          <p>
+            We implement appropriate technical and organizational safeguards to protect your
+            personal information against unauthorized access, alteration, disclosure, or destruction.
+            While we strive to secure your data, please understand that no method of transmission or
+            storage is entirely risk-free. If you have reason to believe that your interaction with
+            us is no longer secure, contact us immediately using the details below.
+          </p>
+
+          <h2>Retention of Information</h2>
+          <p>
+            We retain personal information for as long as necessary to fulfill the purposes outlined
+            in this policy and to comply with legal, regulatory, or ethical obligations. When
+            information is no longer required, we will delete or anonymize it in a secure manner.
+          </p>
+
+          <h2>Your Rights and Choices</h2>
+          <p>
+            Depending on your location, you may have rights to access, correct, update, or delete the
+            personal information we hold about you. You may also object to certain processing,
+            request restrictions, or withdraw consent. To exercise these rights, contact us at
+            <a href="mailto:info@jameskennedypllc.com">info@jameskennedypllc.com</a>.
+          </p>
+
+          <h2>Children's Privacy</h2>
+          <p>
+            The Site is not intended for individuals under the age of 13, and we do not knowingly
+            collect personal information from children. If we discover that a child has provided us
+            with personal data, we will promptly delete it. Parents or guardians who believe their
+            child has submitted information should contact us for assistance.
+          </p>
+
+          <h2>Changes to This Policy</h2>
+          <p>
+            We may update this Privacy Policy periodically to reflect changes in legal requirements
+            or our data practices. When we make material updates, we will revise the "Last Updated"
+            date at the top of the page and, where appropriate, provide additional notice.
+          </p>
+
+          <h2>Contact Us</h2>
+          <p>
+            If you have questions about this Privacy Policy or our privacy practices, please contact
+            James Kennedy, P.L.L.C. at 6216 Gateway Blvd. East, El Paso, TX 79905, by phone at
+            <a href="tel:9155445200">915-544-5200</a>, or by email at
+            <a href="mailto:info@jameskennedypllc.com">info@jameskennedypllc.com</a>.
+          </p>
+
+          <p class="last-updated">Last updated: April 5, 2024</p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>&copy; <span id="year"></span> James Kennedy, P.L.L.C. All rights reserved.</p>
+        <div class="footer-links">
+          <a href="index.html#about">About</a>
+          <a href="index.html#practice-areas">Practice Areas</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html">Contact</a>
+          <a href="privacy-policy.html" class="active">Privacy Policy</a>
+          <a href="disclaimer.html">Disclaimer</a>
+        </div>
+      </div>
+    </footer>
+
+    <div class="cookie-banner" id="cookie-banner" role="dialog" aria-live="polite">
+      <div class="container cookie-banner__inner">
+        <p>
+          This website uses cookies to analyze site traffic and improve your experience. By
+          clicking “Accept,” you consent to the use of cookies in accordance with our
+          <a href="privacy-policy.html">Privacy Policy</a>.
+        </p>
+        <button class="btn primary" id="cookie-accept" type="button">Accept</button>
+      </div>
+    </div>
+
+    <script src="assets/js/main.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- remove the navigation block from blog, contact, privacy, and disclaimer pages so only the home page retains the full header menu
- keep the call-to-action pill visible on interior headers across breakpoints after removing the collapsible navigation

## Testing
- Not run (static site; no automated tests provided)

------
https://chatgpt.com/codex/tasks/task_e_68cdae3e5b1483228f15bd16fd3bd74f